### PR TITLE
Also dispatch to custom component if node is an array.

### DIFF
--- a/packages/myst-to-react/src/MyST.tsx
+++ b/packages/myst-to-react/src/MyST.tsx
@@ -20,7 +20,7 @@ export function MyST({ ast }: { ast?: GenericNode | GenericNode[] }) {
   return (
     <>
       {ast?.map((node) => {
-        const Component = renderers[node.type] ?? DefaultComponent;
+        const Component = renderers[node.type] ?? renderers['DefaultComponent'] ?? DefaultComponent;
         return <Component key={node.key} node={node} />;
       })}
     </>


### PR DESCRIPTION
I just came across that while re-reading the code. I think that's what we meant yesterday.

Also, that make me think that maybe we should revisit that, and have 

```
if (!Array.isArray(ast)){
  ast = [ast]
}
/// unconditionally call the map code ?
```

That might avoid code duplication ?