### PR TITLE
🚥 allow CONTENT_CDN host to be spec'ed

### DIFF
--- a/.changeset/serious-beds-jog.md
+++ b/.changeset/serious-beds-jog.md
@@ -1,0 +1,6 @@
+---
+'@myst-theme/article': patch
+'@myst-theme/book': patch
+---
+
+Theme now looks to CONTENT_CDN_HOST for static url re-writing

--- a/themes/article/app/utils/loaders.server.ts
+++ b/themes/article/app/utils/loaders.server.ts
@@ -38,7 +38,6 @@ function updateLink(url: string) {
   if (process.env.MODE === 'static') {
     return `/myst_assets_folder${url}`;
   }
-  console.log('rewriting:', url, `${CONTENT_CDN}${url}`);
   return `${CONTENT_CDN}${url}`;
 }
 

--- a/themes/article/app/utils/loaders.server.ts
+++ b/themes/article/app/utils/loaders.server.ts
@@ -10,8 +10,10 @@ import {
 } from '@myst-theme/common';
 import { responseNoArticle, responseNoSite, getDomainFromRequest } from '@myst-theme/site';
 
-const HOST_URL = process.env.CONTENT_CDN_HOST ? new URL(process.env.CONTENT_CDN_HOST) : undefined;
-const CONTENT_CDN_HOST = HOST_URL ? HOST_URL.hostname : 'localhost';
+const CONTENT_CDN_HOST =
+  process.env.CONTENT_CDN_HOST && process.env.CONTENT_CDN_HOST.startsWith('http')
+    ? new URL(process.env.CONTENT_CDN_HOST).hostname
+    : process.env.CONTENT_CDN_HOST ?? 'localhost';
 const CONTENT_CDN_PORT = process.env.CONTENT_CDN_PORT ?? '3100';
 const CONTENT_CDN = `http://${CONTENT_CDN_HOST}:${CONTENT_CDN_PORT}`;
 

--- a/themes/article/app/utils/loaders.server.ts
+++ b/themes/article/app/utils/loaders.server.ts
@@ -10,8 +10,10 @@ import {
 } from '@myst-theme/common';
 import { responseNoArticle, responseNoSite, getDomainFromRequest } from '@myst-theme/site';
 
+const HOST_URL = process.env.CONTENT_CDN_HOST ? new URL(process.env.CONTENT_CDN_HOST) : undefined;
+const CONTENT_CDN_HOST = HOST_URL ? HOST_URL.hostname : 'localhost';
 const CONTENT_CDN_PORT = process.env.CONTENT_CDN_PORT ?? '3100';
-const CONTENT_CDN = `http://localhost:${CONTENT_CDN_PORT}`;
+const CONTENT_CDN = `http://${CONTENT_CDN_HOST}:${CONTENT_CDN_PORT}`;
 
 export async function getConfig(): Promise<SiteManifest> {
   const url = `${CONTENT_CDN}/config.json`;
@@ -34,6 +36,7 @@ function updateLink(url: string) {
   if (process.env.MODE === 'static') {
     return `/myst_assets_folder${url}`;
   }
+  console.log('rewriting:', url, `${CONTENT_CDN}${url}`);
   return `${CONTENT_CDN}${url}`;
 }
 

--- a/themes/book/app/utils/loaders.server.ts
+++ b/themes/book/app/utils/loaders.server.ts
@@ -10,8 +10,10 @@ import {
 import { redirect } from '@remix-run/node';
 import { responseNoArticle, responseNoSite, getDomainFromRequest } from '@myst-theme/site';
 
-const HOST_URL = process.env.CONTENT_CDN_HOST ? new URL(process.env.CONTENT_CDN_HOST) : undefined;
-const CONTENT_CDN_HOST = HOST_URL ? HOST_URL.hostname : 'localhost';
+const CONTENT_CDN_HOST =
+  process.env.CONTENT_CDN_HOST && process.env.CONTENT_CDN_HOST.startsWith('http')
+    ? new URL(process.env.CONTENT_CDN_HOST).hostname
+    : process.env.CONTENT_CDN_HOST ?? 'localhost';
 const CONTENT_CDN_PORT = process.env.CONTENT_CDN_PORT ?? '3100';
 const CONTENT_CDN = `http://${CONTENT_CDN_HOST}:${CONTENT_CDN_PORT}`;
 

--- a/themes/book/app/utils/loaders.server.ts
+++ b/themes/book/app/utils/loaders.server.ts
@@ -38,7 +38,6 @@ function updateLink(url: string) {
   if (process.env.MODE === 'static') {
     return `/myst_assets_folder${url}`;
   }
-  console.log('rewriting:', url, `${CONTENT_CDN}${url}`);
   return `${CONTENT_CDN}${url}`;
 }
 

--- a/themes/book/app/utils/loaders.server.ts
+++ b/themes/book/app/utils/loaders.server.ts
@@ -10,8 +10,10 @@ import {
 import { redirect } from '@remix-run/node';
 import { responseNoArticle, responseNoSite, getDomainFromRequest } from '@myst-theme/site';
 
+const HOST_URL = process.env.CONTENT_CDN_HOST ? new URL(process.env.CONTENT_CDN_HOST) : undefined;
+const CONTENT_CDN_HOST = HOST_URL ? HOST_URL.hostname : 'localhost';
 const CONTENT_CDN_PORT = process.env.CONTENT_CDN_PORT ?? '3100';
-const CONTENT_CDN = `http://localhost:${CONTENT_CDN_PORT}`;
+const CONTENT_CDN = `http://${CONTENT_CDN_HOST}:${CONTENT_CDN_PORT}`;
 
 export async function getConfig(): Promise<SiteManifest> {
   const url = `${CONTENT_CDN}/config.json`;
@@ -34,6 +36,7 @@ function updateLink(url: string) {
   if (process.env.MODE === 'static') {
     return `/myst_assets_folder${url}`;
   }
+  console.log('rewriting:', url, `${CONTENT_CDN}${url}`);
   return `${CONTENT_CDN}${url}`;
 }
 


### PR DESCRIPTION
fixing #342 

This allows the hostname used in the `CONTENT_CDN` to be specified independent of `PORT` or `HOST`. 

Note trying to use `HOST` for this purpose is problematic as the express development server attempts to bind to this and fails, we really just want to influence rewriting on urls to static assets, so we are adding `CONTENT_CDN_HOST` in a similar vein to how `CONTENT_CDN_PORT` is used.

A parallel change in `mystmd` is needed in order to add `CONTENT_CDN_HOST` based on `HOST` when starting the dev server (potentially only when `--keep-host` is used?)