### PR TITLE
:mag: Add title for Jupyter Notebook badge

### DIFF
--- a/.changeset/kind-glasses-fix.md
+++ b/.changeset/kind-glasses-fix.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/frontmatter': patch
+---
+
+Add a tooltip for the Jupyter Notebook icon

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -247,7 +247,12 @@ export function FrontmatterBlock({
               <GitHubLink github={github} />
               {isJupyter && (
                 <div className="inline-block mr-1">
-                  <JupyterIcon width="1.25rem" height="1.25rem" className="inline-block" />
+                  <JupyterIcon
+                    width="1.25rem"
+                    height="1.25rem"
+                    className="inline-block"
+                    title="Jupyter Notebook"
+                  />
                 </div>
               )}
             </>


### PR DESCRIPTION
This adds a tooltip for the Jupyter Notebook icon in the headers.