### PR TITLE
:pen: Improve UX for small viewports

### DIFF
--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -150,8 +150,8 @@ export function TopNav() {
   const { logo, logo_dark, logo_text } = config?.options ?? {};
   return (
     <div className="bg-white/80 backdrop-blur dark:bg-stone-900/80 shadow dark:shadow-stone-700 p-3 md:px-8 fixed w-screen top-0 z-30 h-[60px]">
-      <nav className="flex items-center justify-between flex-wrap max-w-[1440px] mx-auto">
-        <div className="flex flex-row xl:min-w-[19.5rem] mr-2 sm:mr-7 justify-start items-center">
+      <nav className="flex items-center justify-between flex-nowrap max-w-[1440px] mx-auto">
+        <div className="flex flex-row xl:min-w-[19.5rem] mr-2 sm:mr-7 justify-start items-center shrink-0">
           <div className="block xl:hidden">
             <button
               className="flex items-center border-stone-400 text-stone-800 hover:text-stone-900 dark:text-stone-200 hover:dark:text-stone-100"

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -149,7 +149,7 @@ export function TopNav() {
   const { title, nav, actions } = config ?? {};
   const { logo, logo_dark, logo_text } = config?.options ?? {};
   return (
-    <div className="bg-white/80 backdrop-blur dark:bg-stone-900/80 shadow dark:shadow-stone-700 p-3 md:px-8 fixed w-screen top-0 z-30 h-[60px]">
+    <div className="bg-white/80 backdrop-blur dark:bg-stone-900/80 shadow dark:shadow-stone-700 p-3 md:px-8 sticky w-screen top-0 z-30 h-[60px]">
       <nav className="flex items-center justify-between flex-nowrap max-w-[1440px] mx-auto">
         <div className="flex flex-row xl:min-w-[19.5rem] mr-2 sm:mr-7 justify-start items-center shrink-0">
           <div className="block xl:hidden">


### PR DESCRIPTION
Right now, our small-screen book-theme behaviour is:

1. ![Screen Shot 2024-07-30 at 18 03 07](https://github.com/user-attachments/assets/e33e92c6-6c69-4de1-bb90-707e11bca680)
2. ![image](https://github.com/user-attachments/assets/4f80fc7f-6c15-4cdc-9cd3-5ab29ea041a1)
3. ![Screen Shot 2024-07-30 at 18 04 19](https://github.com/user-attachments/assets/6b59ada7-4570-4411-82ea-44564735c704)
4. ![Screen Shot 2024-07-30 at 18 06 58](https://github.com/user-attachments/assets/cfe8f388-dbfe-4fad-b21b-ad227a3fbe6e)
5. ![image](https://github.com/user-attachments/assets/83d56b78-34ff-4e1f-a05d-50e63d5694bb)
6. ![image](https://github.com/user-attachments/assets/8ee64727-3205-4265-add8-72badbb9eb3b)


With this PR, it is

1. ![Screen Shot 2024-07-30 at 18 05 17](https://github.com/user-attachments/assets/3d8c15a6-c3e8-4c0a-8940-adb5853ad321)
2. ![image](https://github.com/user-attachments/assets/96699efe-9439-419f-8c7c-bc7b544e7317)
3. ![Screen Shot 2024-07-30 at 18 05 55](https://github.com/user-attachments/assets/f93a6c38-11be-4b30-8735-358720d932e5)
4. ![Screen Shot 2024-07-30 at 18 06 06](https://github.com/user-attachments/assets/1c81a4cf-919d-4356-8a95-068557346a75)
5. ![Screen Shot 2024-07-30 at 18 08 59](https://github.com/user-attachments/assets/c30fdd64-c95b-4e3a-a28b-4b5f92935b18)
6. ![Screen Shot 2024-07-30 at 18 06 20](https://github.com/user-attachments/assets/af148348-e951-4075-9656-1834124842e0)

At a high level, we disable flex-wrap in the navbar, change the navbar to sticky, and prevent the logo from shrinking.

This starts to address https://github.com/jupyter-book/mystmd/issues/948

Next steps will be to move the vanishing navigation bar to the primary sidebar, and probably move the `logo_text` too.