### PR TITLE
📏 Allow full-length TOC when sidebar is useable

### DIFF
--- a/.changeset/cyan-taxis-help.md
+++ b/.changeset/cyan-taxis-help.md
@@ -1,0 +1,7 @@
+---
+'@myst-theme/providers': patch
+'@myst-theme/site': patch
+'@myst-theme/book': patch
+---
+
+Grow TOC on narrow screens

--- a/packages/providers/src/ui.tsx
+++ b/packages/providers/src/ui.tsx
@@ -30,7 +30,7 @@ export function useNavOpen(): [boolean, (open: boolean) => void] {
   return [state?.isNavOpen ?? false, setOpen];
 }
 
-export function isWide(): boolean {
+export function useIsWide(): boolean {
   const [state, _] = useContext(UiContext) ?? [];
   return state?.isWide ?? false;
 }

--- a/packages/providers/src/ui.tsx
+++ b/packages/providers/src/ui.tsx
@@ -3,11 +3,12 @@ import { useMediaQuery } from './hooks.js';
 
 type UiState = {
   isNavOpen?: boolean;
+  isWide?: boolean;
 };
 
 type UiContextType = [UiState, (state: UiState) => void];
 
-const UiContext = createContext<UiContextType | undefined>(undefined);
+export const UiContext = createContext<UiContextType | undefined>(undefined);
 
 // Create a provider for components to consume and subscribe to changes
 export function UiStateProvider({ children }: { children: React.ReactNode }) {
@@ -15,7 +16,7 @@ export function UiStateProvider({ children }: { children: React.ReactNode }) {
   const wide = useMediaQuery('(min-width: 1280px)');
   const [state, setState] = useState<UiState>({ isNavOpen: false });
   useEffect(() => {
-    if (wide) setState({ ...state, isNavOpen: false });
+    if (wide) setState({ ...state, isNavOpen: false, isWide: wide });
   }, [wide]);
   return <UiContext.Provider value={[state, setState]}>{children}</UiContext.Provider>;
 }
@@ -27,4 +28,9 @@ export function useNavOpen(): [boolean, (open: boolean) => void] {
     setState?.({ ...state, isNavOpen: open });
   };
   return [state?.isNavOpen ?? false, setOpen];
+}
+
+export function isWide(): boolean {
+  const [state, _] = useContext(UiContext) ?? [];
+  return state?.isWide ?? false;
 }

--- a/packages/providers/src/ui.tsx
+++ b/packages/providers/src/ui.tsx
@@ -31,6 +31,6 @@ export function useNavOpen(): [boolean, (open: boolean) => void] {
 }
 
 export function useIsWide(): boolean {
-  const [state, _] = useContext(UiContext) ?? [];
+  const [state] = useContext(UiContext) ?? [];
   return state?.isWide ?? false;
 }

--- a/packages/site/src/components/Navigation/PrimarySidebar.tsx
+++ b/packages/site/src/components/Navigation/PrimarySidebar.tsx
@@ -6,6 +6,7 @@ import {
   useSiteManifest,
   useGridSystemProvider,
   useThemeTop,
+  isWide,
 } from '@myst-theme/providers';
 import type { Heading } from '@myst-theme/common';
 import { Toc } from './TableOfContentsItems.js';
@@ -95,10 +96,15 @@ export function useSidebarHeight<T extends HTMLElement = HTMLElement>(top = 0, i
   const container = useRef<T>(null);
   const toc = useRef<HTMLDivElement>(null);
   const transitionState = useNavigation().state;
+  const wide = isWide();
   const setHeight = () => {
     if (!container.current || !toc.current) return;
     const height = container.current.offsetHeight - window.scrollY;
     const div = toc.current.firstChild as HTMLDivElement;
+    if (div)
+      div.style.height = wide
+        ? `min(calc(100vh - ${top}px), ${height + inset}px)`
+        : `calc(100vh - ${top}px)`;
     if (div) div.style.height = `min(calc(100vh - ${top}px), ${height + inset}px)`;
     const nav = toc.current.querySelector('nav');
     if (nav) nav.style.opacity = height > 150 ? '1' : '0';
@@ -111,7 +117,7 @@ export function useSidebarHeight<T extends HTMLElement = HTMLElement>(top = 0, i
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [container, toc, transitionState]);
+  }, [container, toc, transitionState, wide]);
   return { container, toc };
 }
 

--- a/packages/site/src/components/Navigation/PrimarySidebar.tsx
+++ b/packages/site/src/components/Navigation/PrimarySidebar.tsx
@@ -6,7 +6,7 @@ import {
   useSiteManifest,
   useGridSystemProvider,
   useThemeTop,
-  isWide,
+  useIsWide,
 } from '@myst-theme/providers';
 import type { Heading } from '@myst-theme/common';
 import { Toc } from './TableOfContentsItems.js';
@@ -96,7 +96,7 @@ export function useSidebarHeight<T extends HTMLElement = HTMLElement>(top = 0, i
   const container = useRef<T>(null);
   const toc = useRef<HTMLDivElement>(null);
   const transitionState = useNavigation().state;
-  const wide = isWide();
+  const wide = useIsWide();
   const setHeight = () => {
     if (!container.current || !toc.current) return;
     const height = container.current.offsetHeight - window.scrollY;

--- a/themes/book/app/routes/$.tsx
+++ b/themes/book/app/routes/$.tsx
@@ -73,7 +73,7 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   return json({ config, page, project });
 };
 
-export function ArticlePageAndNavigation({
+function ArticlePageAndNavigationInternal({
   children,
   hide_toc,
   projectSlug,
@@ -87,7 +87,7 @@ export function ArticlePageAndNavigation({
   const top = useThemeTop();
   const { container, toc } = useSidebarHeight(top, inset);
   return (
-    <UiStateProvider>
+    <>
       <TopNav hideToc={hide_toc} />
       <PrimaryNavigation
         sidebarRef={toc}
@@ -105,6 +105,29 @@ export function ArticlePageAndNavigation({
           {children}
         </article>
       </TabStateProvider>
+    </>
+  );
+}
+
+export function ArticlePageAndNavigation({
+  children,
+  hide_toc,
+  projectSlug,
+  inset = 20, // begin text 20px from the top (aligned with menu)
+}: {
+  hide_toc?: boolean;
+  projectSlug?: string;
+  children: React.ReactNode;
+  inset?: number;
+}) {
+  return (
+    <UiStateProvider>
+      <ArticlePageAndNavigationInternal
+        children={children}
+        hide_toc={hide_toc}
+        projectSlug={projectSlug}
+        inset={inset}
+      />
     </UiStateProvider>
   );
 }


### PR DESCRIPTION
Presently, the TOC is always trimmed to the page length, in full-width OR narrow displays:

- Wide:   
  ![image](https://github.com/user-attachments/assets/777e5a29-d3af-4e87-a2b6-c1ea10891dbd)
- Narrow  
  ![image](https://github.com/user-attachments/assets/85a4b6c2-eb6c-4a95-8a1c-58322d0b2e76)


This PR tweaks the computation to detect when the "wide" media query is true/false:

- Wide:  
  ![image](https://github.com/user-attachments/assets/c2423966-8ada-440c-94d5-8b0fdde6c6ec)
- Narrow:  
  ![image](https://github.com/user-attachments/assets/f174ec10-aad8-4324-9ae2-f2983f5f5b18)

I think there might be some overflow problems, but I don't *think* they're caused by this PR.