### PR TITLE
📅 Fix representation of MyST date strings

### DIFF
--- a/.changeset/new-bags-dance.md
+++ b/.changeset/new-bags-dance.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/frontmatter': patch
+---
+
+Don't apply timezone transforms to date strings

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -74,14 +74,16 @@ export function DateString({
   spacer?: boolean;
 }) {
   if (!date) return null;
-  // Parse the date, either using date's intrinsic timezone, or local timezone
-  const d = new Date(date);
-  // Rebuild the timezone aware date in UTC without applying the TZ shift
-  const utcDate = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  // Parse the date
+  // As this is a YYYY-MM-DD form, the parser interprets this as a UTC date
+  // (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date)
+  const utcDate = new Date(date);
 
+  // Now cast our UTC-date into the local timezone
+  const localDate = new Date(utcDate.getUTCFullYear(), utcDate.getUTCMonth(), utcDate.getUTCDate());
 
-  // Now format as human-readable
-  const dateString = utcDate.toLocaleDateString('en-US', format);
+  // Then format as human-readable in the local timezone.
+  const dateString = localDate.toLocaleDateString('en-US', format);
   return (
     <time dateTime={date} className={classNames({ 'text-spacer': spacer })}>
       {dateString}

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -74,11 +74,20 @@ export function DateString({
   spacer?: boolean;
 }) {
   if (!date) return null;
-  const d = new Date(date); // This is in the users timezone
-  const utcDate = new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  // Parse the date, either using date's intrinsic timezone, or local timezone
+  const d = new Date(date);
+  // Rebuild the timezone aware date in UTC without applying the TZ shift)
+  const utcDate = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+
+  // Format the date as a machine-readable date
+  const isoString = utcDate.toISOString();
+  const match = isoString.match(/^\d+-\d+-\d+/);
+  const isoDateString = match ? match[0] : date;
+
+  // Now format as human-readable
   const dateString = utcDate.toLocaleDateString('en-US', format);
   return (
-    <time dateTime={date} className={classNames({ 'text-spacer': spacer })}>
+    <time dateTime={isoDateString} className={classNames({ 'text-spacer': spacer })}>
       {dateString}
     </time>
   );

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -76,7 +76,7 @@ export function DateString({
   if (!date) return null;
   // Parse the date, either using date's intrinsic timezone, or local timezone
   const d = new Date(date);
-  // Rebuild the timezone aware date in UTC without applying the TZ shift)
+  // Rebuild the timezone aware date in UTC without applying the TZ shift
   const utcDate = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
 
   // Format the date as a machine-readable date

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -79,15 +79,11 @@ export function DateString({
   // Rebuild the timezone aware date in UTC without applying the TZ shift
   const utcDate = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
 
-  // Format the date as a machine-readable date
-  const isoString = utcDate.toISOString();
-  const match = isoString.match(/^\d+-\d+-\d+/);
-  const isoDateString = match ? match[0] : date;
 
   // Now format as human-readable
   const dateString = utcDate.toLocaleDateString('en-US', format);
   return (
-    <time dateTime={isoDateString} className={classNames({ 'text-spacer': spacer })}>
+    <time dateTime={date} className={classNames({ 'text-spacer': spacer })}>
       {dateString}
     </time>
   );


### PR DESCRIPTION
This PR is the counterpart to https://github.com/jupyter-book/mystmd/pull/1426 which ensures that the validated frontmatter contains `yyyy-mm-dd` formatted dates as wall-clock dates (i.e. not tied to a timezone).

At the moment, myst-theme incorrectly builds a UTC object, such that the result is TZ sensitive. This PR fixes the date handling such that we're not displaying dates in any timezone; what you put in is what you put out.
- [ ] Fix locale