### PR TITLE
📏 Fix spacing in themes

### DIFF
--- a/.changeset/soft-jobs-clean.md
+++ b/.changeset/soft-jobs-clean.md
@@ -1,0 +1,6 @@
+---
+'@myst-theme/site': patch
+'@myst-theme/book': patch
+---
+
+Fix spacing

--- a/packages/site/src/components/Abstract.tsx
+++ b/packages/site/src/components/Abstract.tsx
@@ -16,7 +16,7 @@ export function Abstract({
   if (!content) return null;
   return (
     <div className={className}>
-      <h2 id={id} className="mb-3 text-base font-semibold group">
+      <h2 id={id} className="mb-3 text-base font-semibold group not-prose">
         {title}
         <HashLink id={id} title={`Link to ${title}`} hover className="ml-2" />
       </h2>

--- a/themes/book/app/routes/$.tsx
+++ b/themes/book/app/routes/$.tsx
@@ -97,7 +97,6 @@ export function ArticlePageAndNavigation({
         <article
           ref={container}
           className="article content article-grid grid-gap"
-          style={{ marginTop: top }}
         >
           {children}
         </article>


### PR DESCRIPTION
I noticed that there are a couple of spacing problems right now in our themes:

1. The `abstract` heading is padded:  
  ![image](https://github.com/user-attachments/assets/c24f9d07-29ee-4047-b944-13cf52c714c8)
2. The article title is too low in book theme, and the document outline too:
  ![image](https://github.com/user-attachments/assets/4f65b5d7-34bb-4232-977c-6f0e017fc2fe)

I think the `abstract` heading should be `not-prose`, as we don't want to pad it. Do you agree @stevejpurves? 

As for `useThemeTop`, it looks like a mistake that it's used in the `main` body. So, I've removed it.
