### PR TITLE
📌 `thebe` deps

### DIFF
--- a/.changeset/many-lemons-worry.md
+++ b/.changeset/many-lemons-worry.md
@@ -1,0 +1,6 @@
+---
+'@myst-theme/jupyter': patch
+'@myst-theme/site': patch
+---
+
+📌 Pin `thebe` dependecies to `0.4.7`

--- a/package-lock.json
+++ b/package-lock.json
@@ -39651,9 +39651,9 @@
         "nbtx": "^0.2.3",
         "react-syntax-highlighter": "^15.5.0",
         "swr": "^2.1.5",
-        "thebe-core": "^0.4.7",
-        "thebe-lite": "^0.4.7",
-        "thebe-react": "^0.4.7",
+        "thebe-core": "0.4.7",
+        "thebe-lite": "0.4.7",
+        "thebe-react": "0.4.7",
         "unist-util-select": "^4.0.3"
       },
       "engines": {
@@ -39892,7 +39892,7 @@
         "nbtx": "^0.2.3",
         "node-cache": "^5.1.2",
         "node-fetch": "^2.6.11",
-        "thebe-react": "^0.4.6",
+        "thebe-react": "0.4.7",
         "unist-util-select": "^4.0.1"
       },
       "devDependencies": {

--- a/packages/jupyter/package.json
+++ b/packages/jupyter/package.json
@@ -40,9 +40,9 @@
     "nbtx": "^0.2.3",
     "react-syntax-highlighter": "^15.5.0",
     "swr": "^2.1.5",
-    "thebe-core": "^0.4.7",
-    "thebe-lite": "^0.4.7",
-    "thebe-react": "^0.4.7",
+    "thebe-core": "0.4.7",
+    "thebe-lite": "0.4.7",
+    "thebe-react": "0.4.7",
     "unist-util-select": "^4.0.3"
   },
   "peerDependencies": {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -37,7 +37,7 @@
     "nbtx": "^0.2.3",
     "node-cache": "^5.1.2",
     "node-fetch": "^2.6.11",
-    "thebe-react": "^0.4.6",
+    "thebe-react": "0.4.7",
     "unist-util-select": "^4.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
`thebe` introduced a breaking API change in the latest patch releases 🫠 `0.4.8`,`.0.4.9` which is causing `thebe` to fail in downstream themes and will break releases here if the lock is removed.

The `myst-theme` changes needed to consume those new APIs are actually in #426 #429 so independently bumping versions and adjusting code here seems counter productive. So this PR is intended as a stopgap until that widget hydration work can come in.