### PR TITLE
📦🔒 fixing peer deps

### DIFF
--- a/.changeset/blue-melons-sin.md
+++ b/.changeset/blue-melons-sin.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/site': patch
+---
+
+Removing remix 2.0 peer dep

--- a/package-lock.json
+++ b/package-lock.json
@@ -39899,8 +39899,8 @@
         "@types/lodash.throttle": "^4.1.7"
       },
       "peerDependencies": {
-        "@remix-run/node": "^1.17 || ^2.0",
-        "@remix-run/react": "^1.17 || ^2.0",
+        "@remix-run/node": "^1.19",
+        "@remix-run/react": "^1.19",
         "@types/react": "^16.8 || ^17.0 || ^18.0",
         "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
         "react": "^16.8 || ^17.0 || ^18.0",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -41,8 +41,8 @@
     "unist-util-select": "^4.0.1"
   },
   "peerDependencies": {
-    "@remix-run/node": "^1.17 || ^2.0",
-    "@remix-run/react": "^1.17 || ^2.0",
+    "@remix-run/node": "^1.19",
+    "@remix-run/react": "^1.19",
     "@types/react": "^16.8 || ^17.0 || ^18.0",
     "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
     "react": "^16.8 || ^17.0 || ^18.0",


### PR DESCRIPTION
`@myst-theme/site` has 2.0 peer deps for remix, which is premature and causing downstream problems. Also we should be pointing to 1.19 not 1.17.