### PR TITLE
🔍 Pass-through MyST search JSON from content-server (1 of 2)

### DIFF
--- a/.changeset/curly-dryers-occur.md
+++ b/.changeset/curly-dryers-occur.md
@@ -1,0 +1,6 @@
+---
+'@myst-theme/article': minor
+'@myst-theme/book': minor
+---
+
+Add `myst.search.json` routing

--- a/themes/article/app/routes/$slug[.json].tsx
+++ b/themes/article/app/routes/$slug[.json].tsx
@@ -1,6 +1,6 @@
 import type { LoaderFunction } from '@remix-run/node';
 import { json } from '@remix-run/node';
-import { getMystXrefJson, getPage } from '~/utils/loaders.server';
+import { getMystXrefJson, getMystSearchJson, getPage } from '~/utils/loaders.server';
 
 function api404(message = 'No API route found at this URL') {
   return json(
@@ -18,6 +18,12 @@ export const loader: LoaderFunction = async ({ request, params }) => {
   if (slug === 'myst.xref') {
     const xref = await getMystXrefJson();
     if (!xref) return new Response('myst.xref.json not found', { status: 404 });
+    return json(xref);
+  }
+  // Handle /myst.search.json as slug
+  else if (slug === 'myst.search') {
+    const xref = await getMystSearchJson();
+    if (!xref) return new Response('myst.search.json not found', { status: 404 });
     return json(xref);
   }
   const data = await getPage(request, { slug }).catch(() => null);

--- a/themes/article/app/utils/loaders.server.ts
+++ b/themes/article/app/utils/loaders.server.ts
@@ -89,6 +89,13 @@ export async function getMystXrefJson(): Promise<Record<string, any> | null> {
   return xrefs;
 }
 
+export async function getMystSearchJson(): Promise<Record<string, any> | null> {
+  const url = updateLink('/myst.search.json');
+  const response = await fetch(url).catch(() => null);
+  if (!response || response.status === 404) return null;
+  return await response.json();
+}
+
 export async function getFavicon(): Promise<{ contentType: string | null; buffer: Buffer } | null> {
   const config = await getConfig();
   const url = updateLink(config.options?.favicon) || 'https://mystmd.org/favicon.ico';

--- a/themes/book/app/routes/($project)_.$slug[.json].tsx
+++ b/themes/book/app/routes/($project)_.$slug[.json].tsx
@@ -1,7 +1,7 @@
 import { isFlatSite } from '@myst-theme/common';
 import type { LoaderFunction } from '@remix-run/node';
 import { json } from '@remix-run/node';
-import { getConfig, getMystXrefJson, getPage } from '~/utils/loaders.server';
+import { getConfig, getMystXrefJson, getMystSearchJson, getPage } from '~/utils/loaders.server';
 
 function api404(message = 'No API route found at this URL') {
   return json(
@@ -19,6 +19,12 @@ export const loader: LoaderFunction = async ({ request, params }) => {
   if (project === undefined && slug === 'myst.xref') {
     const xref = await getMystXrefJson();
     if (!xref) return new Response('myst.xref.json not found', { status: 404 });
+    return json(xref);
+  }
+  // Handle /myst.search.json as slug
+  else if (slug === 'myst.search') {
+    const xref = await getMystSearchJson();
+    if (!xref) return new Response('myst.search.json not found', { status: 404 });
     return json(xref);
   }
   const config = await getConfig();

--- a/themes/book/app/utils/loaders.server.ts
+++ b/themes/book/app/utils/loaders.server.ts
@@ -89,6 +89,13 @@ export async function getMystXrefJson(): Promise<Record<string, any> | null> {
   return xrefs;
 }
 
+export async function getMystSearchJson(): Promise<Record<string, any> | null> {
+  const url = updateLink('/myst.search.json');
+  const response = await fetch(url).catch(() => null);
+  if (!response || response.status === 404) return null;
+  return await response.json();
+}
+
 export async function getFavicon(): Promise<{ contentType: string | null; buffer: Buffer } | null> {
   const config = await getConfig();
   const url = updateLink(config.options?.favicon) || 'https://mystmd.org/favicon.ico';


### PR DESCRIPTION
This PR adds some simple routing logic to handle `myst.search.json`. Whilst it does not add a UX for consuming this data, third-party tools can use it to search MyST sites.