### PR TITLE
 🤏 Improve theme for narrow screens

### DIFF
--- a/.changeset/tasty-books-applaud.md
+++ b/.changeset/tasty-books-applaud.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/site': patch
+---
+
+Fix small screens with search

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -519,7 +519,7 @@ const SearchPlaceholderButton = forwardRef<
       {...props}
       className={classNames(
         className,
-        'flex items-center h-10 aspect-square sm:w-64 text-left text-gray-400',
+        'flex items-center h-10 aspect-square sm:w-48 sm:max-w-64 text-left text-gray-400',
         'border border-gray-300 dark:border-gray-600',
         'rounded-lg bg-gray-50 dark:bg-gray-700',
         {
@@ -541,11 +541,12 @@ const SearchPlaceholderButton = forwardRef<
 
 export interface SearchProps {
   debounceTime?: number;
+  className?: string;
 }
 /**
  * Component that implements a basic search interface
  */
-export function Search({ debounceTime = 500 }: SearchProps) {
+export function Search({ debounceTime = 500, className }: SearchProps) {
   const [open, setOpen] = useState(false);
   const [searchResults, setSearchResults] = useState<RankedSearchResult[] | undefined>();
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -582,7 +583,7 @@ export function Search({ debounceTime = 500 }: SearchProps) {
   return (
     <Dialog.Root open={open} onOpenChange={setOpen}>
       <Dialog.Trigger asChild>
-        <SearchPlaceholderButton />
+        <SearchPlaceholderButton className={className} />
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-[#656c85cc] z-[1000]" />

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -95,7 +95,7 @@ export function NavItem({ item }: { item: SiteNavItem }) {
 export function NavItems({ nav }: { nav?: SiteManifest['nav'] }) {
   if (!nav) return null;
   return (
-    <div className="flex-grow hidden text-md lg:block">
+    <div className="hidden text-md lg:block">
       {nav.map((item) => {
         return <NavItem key={'url' in item ? item.url : item.title} item={item} />;
       })}
@@ -111,7 +111,7 @@ export function TopNav({ hideToc, hideSearch }: { hideToc?: boolean; hideSearch?
   return (
     <div className="bg-white/80 backdrop-blur dark:bg-stone-900/80 shadow dark:shadow-stone-700 p-3 md:px-8 sticky w-screen top-0 z-30 h-[60px]">
       <nav className="flex items-center justify-between flex-nowrap max-w-[1440px] mx-auto">
-        <div className="flex flex-row xl:min-w-[19.5rem] mr-2 sm:mr-7 justify-start items-center shrink-0">
+        <div className="flex flex-row xl:min-w-[19.5rem] mr-2 sm:mr-7 justify-start items-center shrink-0 grow-0">
           {!hideToc && (
             <div className="block xl:hidden">
               <button
@@ -127,15 +127,15 @@ export function TopNav({ hideToc, hideSearch }: { hideToc?: boolean; hideSearch?
           )}
           <HomeLink name={title} logo={logo} logoDark={logo_dark} logoText={logo_text} />
         </div>
-        <div className="flex items-center flex-grow w-auto">
+        <div className="flex items-center shrink-0 grow w-auto">
           <NavItems nav={nav} />
-          <div className="flex-grow block"></div>
-          {!hideSearch && <Search />}
-          <ThemeButton />
-          <div className="block sm:hidden">
+          <div className="grow block"></div>
+          {!hideSearch && <Search className="grow-0 sm:grow" />}
+          <ThemeButton className="w-8 h-8 mx-3 shrink-0 grow-0" />
+          <div className="block sm:hidden shrink-0">
             <ActionMenu actions={actions} />
           </div>
-          <div className="hidden sm:block">
+          <div className="hidden sm:block shrink-0">
             {actions?.map((action, index) => (
               <ExternalOrInternalLink
                 key={action.url || index}


### PR DESCRIPTION
This PR sets some flex styling to avoid shrinkage causing issues at intermediate widths.
This PR does not address the need to perhaps tweak the menu breakpoints / move the theme button into the ellipsis menu.

Existing:
- Unnecessarily wide search bar
- Stretched theme icon
- Warped action button(s)

![image](https://github.com/user-attachments/assets/af6d44a1-c974-4fda-af26-35bd011bcdb9)


New: 
- Narrower search bar
- Non-growing/shrinking (square) theme icon
- Non-shrinking action button(s)

![image](https://github.com/user-attachments/assets/d5a89b36-169c-429b-8615-73e51627b6f6)
