### PR TITLE
👩‍💻 Fix SSR styling of code-blocks

### DIFF
--- a/.changeset/shiny-rocks-approve.md
+++ b/.changeset/shiny-rocks-approve.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Fix themeing of code-blocks


### PR DESCRIPTION
Recent theme work moved theme logic entirely client-side[^note], so that we can support client-only theme configuration (`localStorage`).

This PR is one "hacky" fix which duplicates each `<pre>` tag, and sets the dark and light styles respectively. Visibility is then class-driven. I don't immediately know if this is a performance nightmare.

[^note]: Technically SSR can render the proper state server-side, but for first-visits, we have to wait for the client to compute the proper state (and do some hydration-hacks to resolve the state).