### PR TITLE
🏗 Support parts mdast trees in page frontmatter

### DIFF
--- a/.changeset/itchy-doors-leave.md
+++ b/.changeset/itchy-doors-leave.md
@@ -1,0 +1,12 @@
+---
+'myst-to-react': patch
+'@myst-theme/frontmatter': patch
+'myst-demo': patch
+'@myst-theme/providers': patch
+'@myst-theme/common': patch
+'@myst-theme/article': patch
+'@myst-theme/site': patch
+'@myst-theme/book': patch
+---
+
+Support parts mdast trees in page frontmatter

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -45,7 +45,8 @@ export type FooterLinks = {
   };
 };
 
-type PageFrontmatterWithDownloads = Omit<PageFrontmatter, 'downloads' | 'exports'> & {
+type PageFrontmatterWithDownloads = Omit<PageFrontmatter, 'parts' | 'downloads' | 'exports'> & {
+  parts?: Record<string, GenericParent>;
   downloads?: SiteAction[];
   exports?: SiteExport[];
 };

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -46,7 +46,7 @@ export type FooterLinks = {
 };
 
 type PageFrontmatterWithDownloads = Omit<PageFrontmatter, 'parts' | 'downloads' | 'exports'> & {
-  parts?: Record<string, GenericParent>;
+  parts?: Record<string, { frontmatter?: PageFrontmatter; mdast: GenericParent }>;
   downloads?: SiteAction[];
   exports?: SiteExport[];
 };

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -188,28 +188,31 @@ export function updatePageStaticLinksInplace(data: PageLoader, updateUrl: Update
       return { ...exp, url: updateUrl(exp.url) };
     });
   }
-  // Fix all of the images to point to the CDN
-  const images = selectAll('image', data.mdast) as Image[];
-  images.forEach((node) => {
-    node.url = updateUrl(node.url);
-    if (node.urlOptimized) {
-      node.urlOptimized = updateUrl(node.urlOptimized);
-    }
-  });
-  const links = selectAll('link,linkBlock,card', data.mdast) as Link[];
-  const staticLinks = links.filter((node) => node.static);
-  staticLinks.forEach((node) => {
-    // These are static links to thinks like PDFs or other referenced files
-    node.url = updateUrl(node.url);
-  });
-  const outputs = selectAll('output', data.mdast) as Output[];
-  outputs.forEach((node) => {
-    if (!node.data) return;
-    walkOutputs(node.data, (obj) => {
-      // The path will be defined from output of myst
-      // Here we are re-assigning it to the current domain
-      if (!obj.path) return;
-      obj.path = updateUrl(obj.path);
+  const allMdastTrees = [data.mdast, ...Object.values(data.frontmatter?.parts ?? {})];
+  allMdastTrees.forEach((tree) => {
+    // Fix all of the images to point to the CDN
+    const images = selectAll('image', tree) as Image[];
+    images.forEach((node) => {
+      node.url = updateUrl(node.url);
+      if (node.urlOptimized) {
+        node.urlOptimized = updateUrl(node.urlOptimized);
+      }
+    });
+    const links = selectAll('link,linkBlock,card', tree) as Link[];
+    const staticLinks = links.filter((node) => node.static);
+    staticLinks.forEach((node) => {
+      // These are static links to thinks like PDFs or other referenced files
+      node.url = updateUrl(node.url);
+    });
+    const outputs = selectAll('output', tree) as Output[];
+    outputs.forEach((node) => {
+      if (!node.data) return;
+      walkOutputs(node.data, (obj) => {
+        // The path will be defined from output of myst
+        // Here we are re-assigning it to the current domain
+        if (!obj.path) return;
+        obj.path = updateUrl(obj.path);
+      });
     });
   });
   return data;

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -188,23 +188,23 @@ export function updatePageStaticLinksInplace(data: PageLoader, updateUrl: Update
       return { ...exp, url: updateUrl(exp.url) };
     });
   }
-  const allMdastTrees = [data.mdast, ...Object.values(data.frontmatter?.parts ?? {})];
-  allMdastTrees.forEach((tree) => {
+  const allMdastTrees = [data, ...Object.values(data.frontmatter?.parts ?? {})];
+  allMdastTrees.forEach(({ mdast }) => {
     // Fix all of the images to point to the CDN
-    const images = selectAll('image', tree) as Image[];
+    const images = selectAll('image', mdast) as Image[];
     images.forEach((node) => {
       node.url = updateUrl(node.url);
       if (node.urlOptimized) {
         node.urlOptimized = updateUrl(node.urlOptimized);
       }
     });
-    const links = selectAll('link,linkBlock,card', tree) as Link[];
-    const staticLinks = links.filter((node) => node.static);
+    const links = selectAll('link,linkBlock,card', mdast) as Link[];
+    const staticLinks = links?.filter((node) => node.static);
     staticLinks.forEach((node) => {
       // These are static links to thinks like PDFs or other referenced files
       node.url = updateUrl(node.url);
     });
-    const outputs = selectAll('output', tree) as Output[];
+    const outputs = selectAll('output', mdast) as Output[];
     outputs.forEach((node) => {
       if (!node.data) return;
       walkOutputs(node.data, (obj) => {

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -194,7 +194,7 @@ export function FrontmatterBlock({
   hideExports,
   className,
 }: {
-  frontmatter: PageFrontmatter;
+  frontmatter: Omit<PageFrontmatter, 'parts'>;
   kind?: SourceFileKind;
   authorStyle?: 'block' | 'list';
   hideBadges?: boolean;

--- a/packages/myst-demo/src/index.tsx
+++ b/packages/myst-demo/src/index.tsx
@@ -386,6 +386,7 @@ export function MySTRenderer({
   );
 
   const mdastStage = astStage === 'pre' ? mdastPre : mdastPost;
+  const { downloads, exports, parts, ...reducedFrontmatter } = frontmatter;
 
   return (
     <figure
@@ -437,7 +438,7 @@ export function MySTRenderer({
         >
           {previewType === 'DEMO' && (
             <>
-              <ReferencesProvider references={references} frontmatter={frontmatter}>
+              <ReferencesProvider references={references} frontmatter={reducedFrontmatter}>
                 {TitleBlock && <TitleBlock frontmatter={frontmatter}></TitleBlock>}
                 <MyST ast={references.article?.children as GenericNode[]} />
               </ReferencesProvider>

--- a/packages/myst-to-react/src/crossReference.tsx
+++ b/packages/myst-to-react/src/crossReference.tsx
@@ -13,7 +13,7 @@ import { InlineError } from './inlineError.js';
 import { default as useSWR } from 'swr';
 import { HoverPopover } from './components/index.js';
 import { MyST } from './MyST.js';
-import type { GenericNode } from 'myst-common';
+import type { GenericNode, GenericParent } from 'myst-common';
 import { selectMdastNodes } from 'myst-common';
 import { scrollToElement } from './hashLink.js';
 
@@ -106,11 +106,11 @@ function useSelectNodes({ load, identifier }: { load?: boolean; identifier: stri
   const { remote, url, remoteBaseUrl, dataUrl } = useXRefState();
   if (!load) return;
   const { data, error } = useFetchMdast({ remote, url, remoteBaseUrl, dataUrl });
-  const mdast = data ? data.mdast : references?.article;
-  const parts = data ? data.frontmatter?.parts : frontmatter?.parts;
+  const mdast = data ? (data.mdast as GenericParent) : references?.article;
+  const parts = data ? (data.frontmatter?.parts as { mdast: GenericParent }) : frontmatter?.parts;
   let nodes: GenericNode[] = [];
   let htmlId: string | undefined;
-  [mdast, ...Object.values(parts ?? {})].forEach((tree) => {
+  [{ mdast }, ...Object.values(parts ?? {})].forEach(({ mdast: tree }) => {
     if (!tree || nodes.length > 0) return;
     const selected = selectMdastNodes(tree, identifier, 3);
     nodes = selected.nodes;
@@ -141,8 +141,8 @@ export function CrossReferenceHover({
   const parent = useXRefState();
   const remoteBaseUrl = remoteBaseUrlIn ?? parent.remoteBaseUrl;
   const remote = !!remoteBaseUrl || parent.remote || remoteIn;
-  const url = parent.remote ? urlIn ?? parent.url : urlIn;
-  const dataUrl = parent.remote ? dataUrlIn ?? parent.dataUrl : dataUrlIn;
+  const url = parent.remote ? (urlIn ?? parent.url) : urlIn;
+  const dataUrl = parent.remote ? (dataUrlIn ?? parent.dataUrl) : dataUrlIn;
   const external = !!remoteBaseUrl || (url?.startsWith('http') ?? false);
   const scroll: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
     e.preventDefault();

--- a/packages/providers/src/references.tsx
+++ b/packages/providers/src/references.tsx
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react';
 import type { References } from 'myst-common';
-import type { PageFrontmatter } from 'myst-frontmatter';
+import type { PageLoader } from '@myst-theme/common';
 
 const ReferencesContext = React.createContext<{
-  frontmatter?: PageFrontmatter;
+  frontmatter?: PageLoader['frontmatter'];
   references?: References;
 }>({});
 
@@ -12,7 +12,7 @@ export function ReferencesProvider({
   frontmatter,
   children,
 }: {
-  frontmatter?: PageFrontmatter;
+  frontmatter?: PageLoader['frontmatter'];
   references?: References;
   children: React.ReactNode;
 }) {

--- a/packages/site/src/pages/Article.tsx
+++ b/packages/site/src/pages/Article.tsx
@@ -42,7 +42,14 @@ export const ArticlePage = React.memo(function ({
   const downloads = combineDownloads(manifest?.downloads, article.frontmatter);
   const tree = copyNode(article.mdast);
   const keywords = article.frontmatter?.keywords ?? [];
-  const parts = { ...extractKnownParts(tree), ...article.frontmatter?.parts };
+  const parts = {
+    ...extractKnownParts(tree),
+    ...Object.fromEntries(
+      Object.entries(article.frontmatter?.parts ?? {}).map(([k, v]) => {
+        return [k, v.mdast];
+      }),
+    ),
+  };
 
   return (
     <ReferencesProvider

--- a/packages/site/src/pages/Article.tsx
+++ b/packages/site/src/pages/Article.tsx
@@ -42,7 +42,7 @@ export const ArticlePage = React.memo(function ({
   const downloads = combineDownloads(manifest?.downloads, article.frontmatter);
   const tree = copyNode(article.mdast);
   const keywords = article.frontmatter?.keywords ?? [];
-  const parts = extractKnownParts(tree);
+  const parts = { ...extractKnownParts(tree), ...article.frontmatter?.parts };
 
   return (
     <ReferencesProvider

--- a/packages/site/src/pages/Article.tsx
+++ b/packages/site/src/pages/Article.tsx
@@ -42,14 +42,7 @@ export const ArticlePage = React.memo(function ({
   const downloads = combineDownloads(manifest?.downloads, article.frontmatter);
   const tree = copyNode(article.mdast);
   const keywords = article.frontmatter?.keywords ?? [];
-  const parts = {
-    ...extractKnownParts(tree),
-    ...Object.fromEntries(
-      Object.entries(article.frontmatter?.parts ?? {}).map(([k, v]) => {
-        return [k, v.mdast];
-      }),
-    ),
-  };
+  const parts = extractKnownParts(tree, article.frontmatter?.parts);
 
   return (
     <ReferencesProvider

--- a/packages/site/src/pages/ErrorUnhandled.tsx
+++ b/packages/site/src/pages/ErrorUnhandled.tsx
@@ -8,7 +8,7 @@ export function ErrorUnhandled({ error }: { error: ErrorResponse }) {
     <>
       <h1>Unexpected Error Occurred</h1>
       <p>Status: {error.status}</p>
-      <p>{error.data.message}</p>
+      <p>{error.data?.message ?? ''}</p>
     </>
   );
 }

--- a/packages/site/src/utils.ts
+++ b/packages/site/src/utils.ts
@@ -18,13 +18,21 @@ export type KnownParts = {
   acknowledgments?: GenericParent;
 };
 
-export function extractKnownParts(tree: GenericParent): KnownParts {
+export function extractKnownParts(
+  tree: GenericParent,
+  parts?: Record<string, { mdast?: GenericParent }>,
+): KnownParts {
   const abstract = extractPart(tree, 'abstract');
   const summary = extractPart(tree, 'summary', { requireExplicitPart: true });
   const keypoints = extractPart(tree, ['keypoints'], { requireExplicitPart: true });
   const data_availability = extractPart(tree, ['data_availability', 'data availability']);
   const acknowledgments = extractPart(tree, ['acknowledgments', 'acknowledgements']);
-  return { abstract, summary, keypoints, data_availability, acknowledgments };
+  const otherParts = Object.fromEntries(
+    Object.entries(parts ?? {}).map(([k, v]) => {
+      return [k, v.mdast];
+    }),
+  );
+  return { abstract, summary, keypoints, data_availability, acknowledgments, ...otherParts };
 }
 
 /**

--- a/themes/article/app/components/Article.tsx
+++ b/themes/article/app/components/Article.tsx
@@ -34,7 +34,14 @@ export function Article({
 }) {
   const keywords = article.frontmatter?.keywords ?? [];
   const tree = copyNode(article.mdast);
-  const parts = { ...extractKnownParts(tree), ...article.frontmatter?.parts };
+  const parts = {
+    ...extractKnownParts(tree),
+    ...Object.fromEntries(
+      Object.entries(article.frontmatter?.parts ?? {}).map(([k, v]) => {
+        return [k, v.mdast];
+      }),
+    ),
+  };
   const { title, subtitle } = article.frontmatter;
   const compute = useComputeOptions();
   const top = useThemeTop();

--- a/themes/article/app/components/Article.tsx
+++ b/themes/article/app/components/Article.tsx
@@ -34,14 +34,7 @@ export function Article({
 }) {
   const keywords = article.frontmatter?.keywords ?? [];
   const tree = copyNode(article.mdast);
-  const parts = {
-    ...extractKnownParts(tree),
-    ...Object.fromEntries(
-      Object.entries(article.frontmatter?.parts ?? {}).map(([k, v]) => {
-        return [k, v.mdast];
-      }),
-    ),
-  };
+  const parts = extractKnownParts(tree, article.frontmatter?.parts);
   const { title, subtitle } = article.frontmatter;
   const compute = useComputeOptions();
   const top = useThemeTop();

--- a/themes/article/app/components/Article.tsx
+++ b/themes/article/app/components/Article.tsx
@@ -34,7 +34,7 @@ export function Article({
 }) {
   const keywords = article.frontmatter?.keywords ?? [];
   const tree = copyNode(article.mdast);
-  const parts = extractKnownParts(tree);
+  const parts = { ...extractKnownParts(tree), ...article.frontmatter?.parts };
   const { title, subtitle } = article.frontmatter;
   const compute = useComputeOptions();
   const top = useThemeTop();

--- a/themes/book/app/components/ArticlePage.tsx
+++ b/themes/book/app/components/ArticlePage.tsx
@@ -74,7 +74,7 @@ export const ArticlePage = React.memo(function ({
   const downloads = combineDownloads(manifest?.downloads, article.frontmatter);
   const tree = copyNode(article.mdast);
   const keywords = article.frontmatter?.keywords ?? [];
-  const parts = extractKnownParts(tree);
+  const parts = { ...extractKnownParts(tree), ...article.frontmatter?.parts };
   const isOutlineMargin = useMediaQuery('(min-width: 1024px)');
   return (
     <ReferencesProvider

--- a/themes/book/app/components/ArticlePage.tsx
+++ b/themes/book/app/components/ArticlePage.tsx
@@ -74,7 +74,14 @@ export const ArticlePage = React.memo(function ({
   const downloads = combineDownloads(manifest?.downloads, article.frontmatter);
   const tree = copyNode(article.mdast);
   const keywords = article.frontmatter?.keywords ?? [];
-  const parts = { ...extractKnownParts(tree), ...article.frontmatter?.parts };
+  const parts = {
+    ...extractKnownParts(tree),
+    ...Object.fromEntries(
+      Object.entries(article.frontmatter?.parts ?? {}).map(([k, v]) => {
+        return [k, v.mdast];
+      }),
+    ),
+  };
   const isOutlineMargin = useMediaQuery('(min-width: 1024px)');
   return (
     <ReferencesProvider

--- a/themes/book/app/components/ArticlePage.tsx
+++ b/themes/book/app/components/ArticlePage.tsx
@@ -74,14 +74,7 @@ export const ArticlePage = React.memo(function ({
   const downloads = combineDownloads(manifest?.downloads, article.frontmatter);
   const tree = copyNode(article.mdast);
   const keywords = article.frontmatter?.keywords ?? [];
-  const parts = {
-    ...extractKnownParts(tree),
-    ...Object.fromEntries(
-      Object.entries(article.frontmatter?.parts ?? {}).map(([k, v]) => {
-        return [k, v.mdast];
-      }),
-    ),
-  };
+  const parts = extractKnownParts(tree, article.frontmatter?.parts);
   const isOutlineMargin = useMediaQuery('(min-width: 1024px)');
   return (
     <ReferencesProvider


### PR DESCRIPTION
This consumes the updates to frontmatter parts introduced in MyST here: https://github.com/jupyter-book/mystmd/pull/1586

Now, the theme may look in page `frontmatter.parts` for additional parts trees. Hopefully this will simplify consuming other custom parts, besides the baked-in "abstract," "acknowledgments," etc.