### PR TITLE
📌 Fix location to executable `.md` files in Thebe

### DIFF
--- a/.changeset/new-students-brush.md
+++ b/.changeset/new-students-brush.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/jupyter': patch
+---
+
+Fix path of non-ipynb files in thebe

--- a/packages/jupyter/src/execute/leaf.tsx
+++ b/packages/jupyter/src/execute/leaf.tsx
@@ -140,9 +140,10 @@ export function SessionStarter({
       // in order to allow for multiple independent sessions of the same notebook
       let path = `/${pageSlug}-${notebookSlug}.ipynb`;
       console.debug('session starter path:', path);
-      const match = location?.match(/(.*)\/.*.ipynb$/) ?? null;
+      const match = location?.match(/(.*)\/.*/) ?? null;
       if (match) {
         console.debug('session starter match:', match);
+        // Choose an arbitrary suffix, not important
         path = `${match[1]}/${pageSlug}-${notebookSlug}.ipynb`;
         console.debug('session starter path (modified):', path);
       }


### PR DESCRIPTION
Users with `.md` files that contain kernelspecs currently report that the `cwd` of running kernels in Thebe (via the power-button UX) is incorrect.

Digging into this, Thebe assumes that we have an `ipynb` file when performing filepath substitution during session provisioning. This means that the `cwd` is incorrect for `.md` files.

This PR relaxes the extension check, and introduces a maybe-incorrect `.ipynb` extension because it's ultimately an arbitrary filename, and we don't then need to use path-handling routines.
