### PR TITLE
💈Use `main` as minimum grid column breakpoint

### DIFF
--- a/.changeset/rich-parrots-explode.md
+++ b/.changeset/rich-parrots-explode.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Set min grid columns at main breakpoint

--- a/packages/myst-to-react/src/grid.tsx
+++ b/packages/myst-to-react/src/grid.tsx
@@ -100,7 +100,7 @@ function gridColumnClasses(columns?: number[]): string {
   }
   return [
     // getColumnClassName(gridClassNames.main, columns[0]),
-    getColumnClassName(gridClassNames.sm, columns[0]),
+    getColumnClassName(gridClassNames.main, columns[0]),
     getColumnClassName(gridClassNames.md, columns[1]),
     getColumnClassName(gridClassNames.lg, columns[2]),
     getColumnClassName(gridClassNames.xl, columns[3]),


### PR DESCRIPTION
For a grid spec `a b c d`, the `a` column number introduces an `sm` breakpoint. This means that for `<sm`, the number of columns is undefined, and defaults to 1. 

I think that users (myself included) would prefer to have direct control over the number of columns at all screen sizes. We could look to increase the number of columns supported, but I think 4 is fine. 