### PR TITLE
🎨 Style scrollbar

### DIFF
--- a/packages/site/src/components/Navigation/PrimarySidebar.tsx
+++ b/packages/site/src/components/Navigation/PrimarySidebar.tsx
@@ -174,7 +174,7 @@ export const PrimarySidebar = ({
           },
         )}
       >
-        <div className="flex-grow py-6 overflow-y-auto">
+        <div className="flex-grow py-6 overflow-y-auto primary-scrollbar">
           {nav && (
             <nav
               aria-label="Navigation"

--- a/styles/toc.css
+++ b/styles/toc.css
@@ -25,3 +25,13 @@
     height: 0;
   }
 }
+
+.primary-scrollbar::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.primary-scrollbar::-webkit-scrollbar-thumb {
+  border-radius: 10px;
+  @apply bg-slate-300/30
+}


### PR DESCRIPTION
Closes https://github.com/jupyter-book/mystmd/issues/1672.

Here is what the changes look like in both light and dark mode for a Chromium-based browser:

![Screenshot 2024-12-17 at 09 44 37](https://github.com/user-attachments/assets/6b06977e-654c-4798-b6ac-119d4bfa9984)
![Screenshot 2024-12-17 at 09 44 41](https://github.com/user-attachments/assets/103e6d48-6912-4dd0-9135-be99c91b6c03)

No changes were needed for Firefox, hence the use of `-webkit-scrollbar` only.

![Screenshot 2024-12-17 at 09 48 19](https://github.com/user-attachments/assets/a555d617-7107-4885-ac78-cfe557d47678)

