### PR TITLE
👈 Disable `hover` modifier for mobile in `HashLink`

### DIFF
--- a/.changeset/heavy-geese-flow.md
+++ b/.changeset/heavy-geese-flow.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Always show hover HashLink on mobile

--- a/packages/myst-to-react/src/hashLink.tsx
+++ b/packages/myst-to-react/src/hashLink.tsx
@@ -61,7 +61,7 @@ export function HashLink({
   id?: string;
   kind?: string;
   title?: string;
-  hover?: boolean;
+  hover?: boolean | 'desktop';
   children?: '#' | '¶' | React.ReactNode;
   canSelectText?: boolean;
   className?: string;
@@ -84,8 +84,9 @@ export function HashLink({
     <a
       className={classNames('no-underline text-inherit hover:text-inherit', className, {
         'select-none': !canSelectText,
+        'transition-opacity opacity-0 focus:opacity-100 group-hover:opacity-70': hover === true,
         '[@media(hover:hover)]:transition-opacity [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:focus:opacity-100 [@media(hover:hover)]:group-hover:opacity-70':
-          hover,
+          hover === 'desktop',
         'hover:underline': !hover,
       })}
       onClick={scroll}

--- a/packages/myst-to-react/src/hashLink.tsx
+++ b/packages/myst-to-react/src/hashLink.tsx
@@ -84,7 +84,8 @@ export function HashLink({
     <a
       className={classNames('no-underline text-inherit hover:text-inherit', className, {
         'select-none': !canSelectText,
-        'transition-opacity opacity-0 focus:opacity-100 group-hover:opacity-70': hover,
+        '[@media(hover:hover)]:transition-opacity [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:focus:opacity-100 [@media(hover:hover)]:group-hover:opacity-70':
+          hover,
         'hover:underline': !hover,
       })}
       onClick={scroll}

--- a/packages/site/src/components/Footnotes.tsx
+++ b/packages/site/src/components/Footnotes.tsx
@@ -50,7 +50,7 @@ export function Footnotes({
                           key={(ref as GenericNode).key}
                           id={`fnref-${(ref as GenericNode).key}`}
                           title="Link to Content"
-                          hover
+                          hover="desktop"
                           className="p-1"
                           children="↩"
                           scrollBehavior="instant"


### PR DESCRIPTION
This simple PR adds a `[@media(hover:hover)]` modifier to the class-names for HashLink instances that use `hover`. The following components are affected:

- `Heading`
- `SolutionRenderer`
- `References`
- `Footnotes`
- `Abstract`
- `Bibliography`
- `Backmatter`
- `Keywords`

This PR was motivated by #513, but I think the same logic holds -- our mobile site should not lose interactivity. It does change the aesthetics, though:

<details><summary>Screenshots</summary>

![Screenshot_20250108_100938_Firefox.png](https://github.com/user-attachments/assets/97be2782-4dc4-4878-b0ca-3db7a7ca5c5e)

![Screenshot_20250108_100934_Firefox.png](https://github.com/user-attachments/assets/274a614c-4d38-4768-a9d5-bb4fa7c72e42)

![Screenshot_20250108_100949_Firefox.png](https://github.com/user-attachments/assets/996bcf61-88b7-4b4a-841a-3693ad1eb736)

</details> 

Forgive the HiDPI images -- I was already playing around with this PR on mobile.