### PR TITLE
✏️ Restore original `title` in `DocumentOutline` of article theme

### DIFF
--- a/.changeset/lovely-cherries-collect.md
+++ b/.changeset/lovely-cherries-collect.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/article': patch
+---
+
+Restore orignial title for article theme

--- a/themes/article/app/components/Article.tsx
+++ b/themes/article/app/components/Article.tsx
@@ -60,7 +60,7 @@ export function Article({
             <FrontmatterBlock
               frontmatter={{ title, subtitle }}
               thebe={thebe}
-	      location={location}
+              location={location}
               className="mb-5"
             />
           )}
@@ -73,8 +73,7 @@ export function Article({
                 className="relative pt-[2px]"
                 maxdepth={outlineMaxDepth}
                 isMargin={isOutlineMargin}
-		title="In this article"
-
+                title="In this article"
               >
                 <SupportingDocuments />
               </DocumentOutline>

--- a/themes/article/app/components/Article.tsx
+++ b/themes/article/app/components/Article.tsx
@@ -73,6 +73,8 @@ export function Article({
                 className="relative pt-[2px]"
                 maxdepth={outlineMaxDepth}
                 isMargin={isOutlineMargin}
+		title="In this article"
+
               >
                 <SupportingDocuments />
               </DocumentOutline>


### PR DESCRIPTION
Follows up from https://github.com/jupyter-book/myst-theme/pull/519