### PR TITLE
Experimental: support disabling pretty-urls (for readthedocs)

### DIFF
--- a/packages/myst-to-react/src/card.tsx
+++ b/packages/myst-to-react/src/card.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { NodeRenderer } from '@myst-theme/providers';
 import classNames from 'classnames';
-import { useLinkProvider, useBaseurl, withBaseurl } from '@myst-theme/providers';
+import { useLinkProvider, useBaseurl, withBaseurl, usePrettyUrl, withPrettyUrl } from '@myst-theme/providers';
 import { MyST } from './MyST.js';
 import type { GenericNode } from 'myst-common';
 
@@ -79,6 +79,7 @@ function ExternalOrInternalLink({
 }) {
   const Link = useLinkProvider();
   const baseurl = useBaseurl();
+  const prettyurl = usePrettyUrl();
   if (to.startsWith('http') || isStatic) {
     return (
       <a href={to} className={className} target="_blank" rel="noopener noreferrer">
@@ -86,8 +87,9 @@ function ExternalOrInternalLink({
       </a>
     );
   }
+  const url = withPrettyUrl(withBaseurl(to, baseurl), prettyurl)
   return (
-    <Link to={withBaseurl(to, baseurl)} className={className} prefetch={prefetch}>
+    <Link to={url} className={className} prefetch={prefetch}>
       {children}
     </Link>
   );

--- a/packages/myst-to-react/src/components/LinkCard.tsx
+++ b/packages/myst-to-react/src/components/LinkCard.tsx
@@ -1,4 +1,4 @@
-import { useLinkProvider, useBaseurl, withBaseurl } from '@myst-theme/providers';
+import { useLinkProvider, useBaseurl, withBaseurl, usePrettyUrl, withPrettyUrl } from '@myst-theme/providers';
 import { ArrowTopRightOnSquareIcon as ExternalLinkIcon } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
 
@@ -21,7 +21,9 @@ export function LinkCard({
 }) {
   const Link = useLinkProvider();
   const baseurl = useBaseurl();
-  const to = withBaseurl(url, baseurl);
+  const prettyurl = usePrettyUrl();
+  // I don't think either should be used with !internal URLs, but it was already like this.
+  const to = withPrettyUrl(withBaseurl(url, baseurl), prettyurl);
   return (
     <div
       className={classNames('hover-card-content rounded overflow-hidden', className, {

--- a/packages/myst-to-react/src/crossReference.tsx
+++ b/packages/myst-to-react/src/crossReference.tsx
@@ -8,6 +8,8 @@ import {
   useXRefState,
   type NodeRenderer,
   useFrontmatter,
+  withPrettyUrl,
+  usePrettyUrl,
 } from '@myst-theme/providers';
 import { InlineError } from './inlineError.js';
 import { default as useSWR } from 'swr';
@@ -141,6 +143,7 @@ export function CrossReferenceHover({
 }) {
   const Link = useLinkProvider();
   const baseurl = useBaseurl();
+  const prettyurl = usePrettyUrl();
   const parent = useXRefState();
   const remoteBaseUrl = remoteBaseUrlIn ?? parent.remoteBaseUrl;
   const remote = !!remoteBaseUrl || parent.remote || remoteIn;
@@ -190,7 +193,7 @@ export function CrossReferenceHover({
         )}
         {remote && !external && (
           <Link
-            to={`${withBaseurl(url, baseurl)}${htmlId ? `#${htmlId}` : ''}`}
+            to={`${withPrettyUrl(withBaseurl(url, baseurl), prettyurl)}${htmlId ? `#${htmlId}` : ''}`}
             prefetch="intent"
             className={classNames({ 'hover-link': !isButtonLike }, className)}
           >

--- a/packages/myst-to-react/src/links/index.tsx
+++ b/packages/myst-to-react/src/links/index.tsx
@@ -3,7 +3,7 @@ import {
   ArrowTopRightOnSquareIcon as ExternalLinkIcon,
   LinkIcon,
 } from '@heroicons/react/24/outline';
-import { useLinkProvider, useSiteManifest, useBaseurl, withBaseurl } from '@myst-theme/providers';
+import { useLinkProvider, useSiteManifest, useBaseurl, withBaseurl, withPrettyUrl, usePrettyUrl } from '@myst-theme/providers';
 import type { SiteManifest } from 'myst-config';
 import type { NodeRenderer, NodeRenderers } from '@myst-theme/providers';
 import { HoverPopover, LinkCard } from '../components/index.js';
@@ -36,10 +36,15 @@ function InternalLink({
   const site = useSiteManifest();
   const page = getPageInfo(site, url);
   const baseurl = useBaseurl();
+  let to = withBaseurl(url, baseurl);
+  if (page) {
+    const prettyurl = usePrettyUrl();
+    to = withPrettyUrl(to, prettyurl)
+  }
   const skipPreview = !page || (!page.description && !page.thumbnail);
   if (!page || skipPreview) {
     return (
-      <Link to={withBaseurl(url, baseurl)} prefetch="intent" className={className}>
+      <Link to={to} prefetch="intent" className={className}>
         {children}
       </Link>
     );
@@ -56,7 +61,7 @@ function InternalLink({
         />
       }
     >
-      <Link to={withBaseurl(url, baseurl)} prefetch="intent" className={className}>
+      <Link to={to} prefetch="intent" className={className}>
         {children}
       </Link>
     </HoverPopover>

--- a/packages/providers/src/index.tsx
+++ b/packages/providers/src/index.tsx
@@ -3,6 +3,7 @@ export * from './theme.js';
 export * from './grid.js';
 export * from './references.js';
 export * from './baseurl.js';
+export * from './pretty.js';
 export * from './ui.js';
 export * from './site.js';
 export * from './search.js';

--- a/packages/providers/src/pretty.tsx
+++ b/packages/providers/src/pretty.tsx
@@ -1,0 +1,34 @@
+import React, { useContext } from 'react';
+
+const PrettyUrlContext = React.createContext<{
+  prettyurl: boolean;
+}>({prettyurl: true});
+
+export function PrettyUrlProvider({
+  prettyurl,
+  children,
+}: {
+  prettyurl?: boolean;
+  children: React.ReactNode;
+}) {
+  if (typeof prettyurl === 'undefined') {
+    prettyurl = true;
+  }
+  return <PrettyUrlContext.Provider value={{ prettyurl }}>{children}</PrettyUrlContext.Provider>;
+}
+
+export function usePrettyUrl() {
+  const data = useContext(PrettyUrlContext);
+  return data.prettyurl;
+}
+
+export function withPrettyUrl(url?: string, prettyurl?: boolean) {
+  if (url && prettyurl === false && !url.endsWith('/')) {
+    // handle fragments, won't work if query params ever happen
+    const segments = url.split('#')
+    segments[0] = segments[0] + '.html'
+    url = segments.join('#')
+    return url
+  }
+  return url as string
+}

--- a/packages/site/src/components/DocumentOutline.tsx
+++ b/packages/site/src/components/DocumentOutline.tsx
@@ -1,8 +1,10 @@
 import {
   useBaseurl,
   useNavLinkProvider,
+  usePrettyUrl,
   useSiteManifest,
   withBaseurl,
+  withPrettyUrl,
 } from '@myst-theme/providers';
 import { useNavigation } from '@remix-run/react';
 import classNames from 'classnames';
@@ -432,6 +434,7 @@ export function SupportingDocuments() {
   const { projects } = useSiteManifest() ?? {};
   const NavLink = useNavLinkProvider();
   const baseurl = useBaseurl();
+  const prettyurl = usePrettyUrl();
   const pages = projects?.[0]?.pages;
   if (!pages || pages.length === 0) return null;
   return (
@@ -446,7 +449,7 @@ export function SupportingDocuments() {
             return (
               <li key={p.slug}>
                 <NavLink
-                  to={withBaseurl(`/${slugToUrl(p.slug)}#main`, baseurl)}
+                  to={withPrettyUrl(withBaseurl(`/${slugToUrl(p.slug)}`, baseurl), prettyurl) + '#main'}
                   prefetch="intent"
                   className={({ isActive }) =>
                     classNames('no-underline flex self-center hover:text-blue-700', {

--- a/packages/site/src/components/FooterLinksBlock.tsx
+++ b/packages/site/src/components/FooterLinksBlock.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
 import type { FooterLinks, NavigationLink } from '@myst-theme/common';
-import { useLinkProvider, useBaseurl, withBaseurl } from '@myst-theme/providers';
+import { useLinkProvider, useBaseurl, withBaseurl, usePrettyUrl, withPrettyUrl } from '@myst-theme/providers';
 
 export const FooterLink = ({
   title,
@@ -11,12 +11,13 @@ export const FooterLink = ({
   right,
 }: NavigationLink & { right?: boolean }) => {
   const baseurl = useBaseurl();
+  const prettyurl = usePrettyUrl();
   const Link = useLinkProvider();
   return (
     <Link
       prefetch="intent"
       className="flex-1 block p-4 font-normal text-gray-600 no-underline border border-gray-200 rounded shadow-sm group hover:border-blue-600 dark:hover:border-blue-400 hover:text-blue-600 dark:hover:text-blue-400 dark:text-gray-100 dark:border-gray-500 hover:shadow-lg dark:shadow-neutral-700"
-      to={withBaseurl(url, baseurl)}
+      to={withPrettyUrl(withBaseurl(url, baseurl), prettyurl)}
     >
       <div className="flex h-full align-middle">
         {right && (

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -29,6 +29,8 @@ import {
   withBaseurl,
   useBaseurl,
   useNavigateProvider,
+  usePrettyUrl,
+  withPrettyUrl,
 } from '@myst-theme/providers';
 
 /**
@@ -220,6 +222,7 @@ function SearchResultItem({
 }) {
   const { hierarchy, type, url, queries } = result;
   const baseurl = useBaseurl();
+  const prettyurl = usePrettyUrl();
   const Link = useLinkProvider();
 
   // Render the icon
@@ -261,7 +264,7 @@ function SearchResultItem({
   return (
     <Link
       className="block px-1 py-2 text-gray-700 rounded shadow-md dark:text-white group-aria-selected:bg-blue-600 group-aria-selected:text-white dark:shadow-none dark:bg-stone-800"
-      to={withBaseurl(url, baseurl)}
+      to={withPrettyUrl(withBaseurl(url, baseurl), prettyurl)}
       // Close the main search on click
       onClick={closeSearch}
     >
@@ -461,6 +464,7 @@ function SearchForm({
   // Handle item selection
   const navigate = useNavigateProvider();
   const baseurl = useBaseurl();
+  const prettyurl = usePrettyUrl();
 
   // Handle item selection and navigation
   const handleSearchKeyPress = useCallback<KeyboardEventHandler<HTMLInputElement>>(
@@ -479,7 +483,7 @@ function SearchForm({
 
         const url = searchResults[selectedIndex]?.url;
         if (url) {
-          navigate(withBaseurl(url, baseurl));
+          navigate(withPrettyUrl(withBaseurl(url, baseurl), prettyurl));
           closeSearch?.();
         }
       }

--- a/packages/site/src/pages/Root.tsx
+++ b/packages/site/src/pages/Root.tsx
@@ -3,6 +3,7 @@ import type { SiteLoader } from '@myst-theme/common';
 import type { NodeRenderers } from '@myst-theme/providers';
 import {
   BaseUrlProvider,
+  PrettyUrlProvider,
   SiteProvider,
   Theme,
   ThemeProvider,
@@ -41,6 +42,7 @@ export function Document({
   title,
   staticBuild,
   baseurl,
+  prettyurl,
   top = DEFAULT_NAV_HEIGHT,
   renderers = defaultRenderers,
 }: {
@@ -51,6 +53,7 @@ export function Document({
   title?: string;
   staticBuild?: boolean;
   baseurl?: string;
+  prettyurl?: boolean;
   top?: number;
   renderers?: NodeRenderers;
 }) {
@@ -82,6 +85,7 @@ export function Document({
         title={title}
         liveReloadListener={!staticBuild}
         baseurl={baseurl}
+        prettyurl={prettyurl}
         top={top}
       />
     </ThemeProvider>
@@ -95,6 +99,7 @@ export function DocumentWithoutProviders({
   config,
   title,
   baseurl,
+  prettyurl,
   top = DEFAULT_NAV_HEIGHT,
   liveReloadListener,
 }: {
@@ -104,6 +109,7 @@ export function DocumentWithoutProviders({
   config?: SiteManifest;
   title?: string;
   baseurl?: string;
+  prettyurl?: boolean;
   useLocalStorageForDarkMode?: boolean;
   top?: number;
   theme?: Theme;
@@ -137,7 +143,9 @@ export function DocumentWithoutProviders({
       </head>
       <body className="m-0 transition-colors duration-500 bg-white dark:bg-stone-900">
         <BaseUrlProvider baseurl={baseurl}>
-          <SiteProvider config={config}>{children}</SiteProvider>
+          <PrettyUrlProvider prettyurl={prettyurl}>
+            <SiteProvider config={config}>{children}</SiteProvider>
+          </PrettyUrlProvider>
         </BaseUrlProvider>
         <ScrollRestoration />
         <Scripts />

--- a/themes/book/app/root.tsx
+++ b/themes/book/app/root.tsx
@@ -79,7 +79,10 @@ function createSearch(index: MystSearchIndex): ISearch {
 
 export default function AppWithReload() {
   const { theme, config, CONTENT_CDN_PORT, MODE, BASE_URL } = useLoaderData<SiteLoader>();
-
+  let prettyurl = config?.options?.pretty_urls as boolean | undefined
+  if (typeof prettyurl === 'undefined') {
+    prettyurl = true;
+  }
   const searchFactory = useCallback((index: MystSearchIndex) => createSearch(index), []);
 
   return (
@@ -90,6 +93,7 @@ export default function AppWithReload() {
         scripts={MODE === 'static' ? undefined : <ContentReload port={CONTENT_CDN_PORT} />}
         staticBuild={MODE === 'static'}
         baseurl={BASE_URL}
+        prettyurl={prettyurl}
       >
         <SkipTo
           targets={[

--- a/themes/book/app/routes/$.tsx
+++ b/themes/book/app/routes/$.tsx
@@ -58,9 +58,22 @@ export const meta: V2_MetaFunction<typeof loader> = ({ data, matches, location }
 
 export const links: LinksFunction = () => [KatexCSS];
 
+export const pretty_urls = (url: string, config: SiteManifest) => {
+  const components = new URL(url).pathname.slice(1).split('/')
+  if (config.options?.pretty_urls === false && components.length > 0) {
+    const lastIdx = components.length - 1;
+    const last = components[lastIdx]
+    if (last.endsWith('.html')) {
+      components[lastIdx] = last.substring(0, last.length - 5)
+    }
+  }
+  return components
+}
+
 export const loader: LoaderFunction = async ({ params, request }) => {
-  const [first, ...rest] = new URL(request.url).pathname.slice(1).split('/');
   const config = await getConfig();
+  let [first, ...rest] = pretty_urls(request.url, config);
+
   const project = getProject(config, first);
   const projectName = project?.slug === first ? first : undefined;
   const slugParts = projectName ? rest : [first, ...rest];

--- a/themes/book/template.yml
+++ b/themes/book/template.yml
@@ -61,6 +61,9 @@ options:
   - type: boolean
     id: folders
     description: Respect nested folder structure in URL paths.
+  - type: boolean
+    id: pretty_urls
+    description: Whether to use static ('/document.html') or pretty ('/document') URLs
 build:
   install: npm install
   start: npm run start


### PR DESCRIPTION
A potential solution to the assumption of URLs without extensions (pretty urls) being served from a bare html file noted in https://github.com/jupyter-book/mystmd/issues/984.

**Limitations:**
 - First time working with this theme, so I probably missed something.
 - No tests yet (want to get feedback on the approach)
 - I've only changed the "book" theme.
 - Doesn't handle the flyout menu in readthedocs, I think that may only need a react upgrade, which I will probably test out soon.

**Approach**
 - Add a site option for `pretty_urls`, it is by default interpreted to be `true`. (I'm not sure if there's a better way to cause a default, but it didn't seem like it since we're relying on the remix loader which just fetches the config.)
 - When false, the book theme will set a React context which various components will look at.
 - I looked at each reference to base_url and worked out if it was relevant. (There is one section that uses base_url in a way that I think might be a bug, but I'm not familiar enough with what "internal" means to this code.)

**Example**
https://genome-sampler.readthedocs.io/en/latest/