### PR TITLE
🛫 Add landing page blocks to book theme

### DIFF
--- a/.changeset/blue-seals-arrive.md
+++ b/.changeset/blue-seals-arrive.md
@@ -1,0 +1,6 @@
+---
+'@myst-theme/landing-pages': patch
+'myst-to-react': patch
+---
+
+Allow for no-width pilcrows on headings.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,6 +14,7 @@
       "@myst-theme/icons",
       "@myst-theme/search",
       "@myst-theme/search-minisearch",
+      "@myst-theme/landing-pages",
       "@myst-theme/book",
       "@myst-theme/article",
       "myst-to-react",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7703,6 +7703,10 @@
       "resolved": "packages/jupyter",
       "link": true
     },
+    "node_modules/@myst-theme/landing-pages": {
+      "resolved": "packages/landing-pages",
+      "link": true
+    },
     "node_modules/@myst-theme/providers": {
       "resolved": "packages/providers",
       "link": true
@@ -39217,6 +39221,17 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-filter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-4.0.1.tgz",
+      "integrity": "sha512-RynicUM/vbOSTSiUK+BnaK9XMfmQUh6gyi7L6taNgc7FIf84GukXVV3ucGzEN/PhUUkdP5hb1MmXc+3cvPUm5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      }
+    },
     "node_modules/unist-util-find-after": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-4.0.1.tgz",
@@ -41250,6 +41265,32 @@
         "ieee754": "^1.2.1"
       }
     },
+    "packages/landing-pages": {
+      "name": "@myst-theme/landing-pages",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@myst-theme/providers": "^0.14.1",
+        "classnames": "^2.5.1",
+        "myst-common": "^1.7.8",
+        "myst-config": "^1.7.8",
+        "myst-frontmatter": "^1.7.8",
+        "myst-spec": "^0.0.5",
+        "myst-spec-ext": "^1.7.8",
+        "myst-to-react": "^0.14.1",
+        "unist-util-filter": "^4.0.0",
+        "unist-util-select": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
     "packages/myst-demo": {
       "version": "0.14.1",
       "license": "MIT",
@@ -41501,6 +41542,7 @@
         "@myst-theme/common": "^0.14.1",
         "@myst-theme/icons": "^0.14.1",
         "@myst-theme/jupyter": "^0.14.1",
+        "@myst-theme/landing-pages": "^0.0.0",
         "@myst-theme/providers": "^0.14.1",
         "@myst-theme/site": "^0.14.1",
         "@myst-theme/styles": "^0.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41272,11 +41272,11 @@
       "dependencies": {
         "@myst-theme/providers": "^0.14.1",
         "classnames": "^2.5.1",
-        "myst-common": "^1.7.8",
-        "myst-config": "^1.7.8",
-        "myst-frontmatter": "^1.7.8",
+        "myst-common": "^1.7.9",
+        "myst-config": "^1.7.9",
+        "myst-frontmatter": "^1.7.9",
         "myst-spec": "^0.0.5",
-        "myst-spec-ext": "^1.7.8",
+        "myst-spec-ext": "^1.7.9",
         "myst-to-react": "^0.14.1",
         "unist-util-filter": "^4.0.0",
         "unist-util-select": "^4.0.3"

--- a/packages/landing-pages/.eslintrc.cjs
+++ b/packages/landing-pages/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['curvenote'],
+};

--- a/packages/landing-pages/README.md
+++ b/packages/landing-pages/README.md
@@ -1,0 +1,6 @@
+# @myst-theme/landing-pages
+
+[![myst-demo on npm](https://img.shields.io/npm/v/@myst-theme/landing-pages.svg)](https://www.npmjs.com/package/@myst-theme/landing-pages)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/curvenote/curvenote/blob/main/LICENSE)
+
+A set of landing-page components for MyST

--- a/packages/landing-pages/package.json
+++ b/packages/landing-pages/package.json
@@ -22,11 +22,11 @@
   "dependencies": {
     "@myst-theme/providers": "^0.14.1",
     "classnames": "^2.5.1",
-    "myst-common": "^1.7.8",
-    "myst-config": "^1.7.8",
-    "myst-frontmatter": "^1.7.8",
+    "myst-common": "^1.7.9",
+    "myst-config": "^1.7.9",
+    "myst-frontmatter": "^1.7.9",
     "myst-spec": "^0.0.5",
-    "myst-spec-ext": "^1.7.8",
+    "myst-spec-ext": "^1.7.9",
     "myst-to-react": "^0.14.1",
     "unist-util-select": "^4.0.3",
     "unist-util-filter": "^4.0.0"

--- a/packages/landing-pages/package.json
+++ b/packages/landing-pages/package.json
@@ -17,9 +17,7 @@
     "lint:format": "prettier --check \"src/**/*.{ts,tsx,md}\"",
     "dev": "npm-run-all --parallel \"build:* -- --watch\"",
     "build:esm": "tsc",
-    "build": "npm-run-all -l clean -p build:esm",
-    "test": "vitest run",
-    "test:watch": "vitest watch"
+    "build": "npm-run-all -l clean -p build:esm"
   },
   "dependencies": {
     "@myst-theme/providers": "^0.14.1",

--- a/packages/landing-pages/package.json
+++ b/packages/landing-pages/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@myst-theme/landing-pages",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=16"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rimraf dist",
+    "lint": "eslint \"src/**/*.ts*\" \"src/**/*.tsx\" -c ./.eslintrc.cjs",
+    "lint:format": "prettier --check \"src/**/*.{ts,tsx,md}\"",
+    "dev": "npm-run-all --parallel \"build:* -- --watch\"",
+    "build:esm": "tsc",
+    "build": "npm-run-all -l clean -p build:esm",
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "dependencies": {
+    "@myst-theme/providers": "^0.14.1",
+    "classnames": "^2.5.1",
+    "myst-common": "^1.7.8",
+    "myst-config": "^1.7.8",
+    "myst-frontmatter": "^1.7.8",
+    "myst-spec": "^0.0.5",
+    "myst-spec-ext": "^1.7.8",
+    "myst-to-react": "^0.14.1",
+    "unist-util-select": "^4.0.3",
+    "unist-util-filter": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@types/react": "^16.8 || ^17.0 || ^18.0",
+    "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  }
+}

--- a/packages/landing-pages/src/BlockHeading.tsx
+++ b/packages/landing-pages/src/BlockHeading.tsx
@@ -1,0 +1,24 @@
+import type { GenericParent } from 'myst-common';
+import { MyST, HashLink } from 'myst-to-react';
+import classNames from 'classnames';
+import React, { createElement as e } from 'react';
+
+export function BlockHeading({ node, className }: { node: GenericParent; className?: string }) {
+  const { enumerator, depth, key, identifier, html_id } = node;
+  const id = html_id || identifier || key;
+
+  return e(
+    `h${depth}`,
+    {
+      className: classNames(node.class, className, 'group'),
+      id: id,
+    },
+    <>
+      {enumerator && <span className="mr-3 select-none">{enumerator}</span>}
+      <span className="heading-text">
+        <MyST ast={node.children} />
+      </span>
+      <HashLink id={id} kind="Section" className="px-2 font-normal" hover hideInPopup />
+    </>,
+  );
+}

--- a/packages/landing-pages/src/BlockHeading.tsx
+++ b/packages/landing-pages/src/BlockHeading.tsx
@@ -1,7 +1,7 @@
+import { createElement as e } from 'react';
 import type { GenericParent } from 'myst-common';
 import { MyST, HashLink } from 'myst-to-react';
 import classNames from 'classnames';
-import React, { createElement as e } from 'react';
 
 export function BlockHeading({ node, className }: { node: GenericParent; className?: string }) {
   const { enumerator, depth, key, identifier, html_id } = node;

--- a/packages/landing-pages/src/BlockHeading.tsx
+++ b/packages/landing-pages/src/BlockHeading.tsx
@@ -18,7 +18,7 @@ export function BlockHeading({ node, className }: { node: GenericParent; classNa
       <span className="heading-text">
         <MyST ast={node.children} />
       </span>
-      <HashLink id={id} kind="Section" className="px-2 font-normal" hover hideInPopup />
+      <HashLink id={id} kind="Section" className="font-normal" hover hideInPopup noWidth />
     </>,
   );
 }

--- a/packages/landing-pages/src/CenteredBlock.tsx
+++ b/packages/landing-pages/src/CenteredBlock.tsx
@@ -70,7 +70,7 @@ export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
 
 const CENTERED_RENDERERS: NodeRenderers = {
   block: {
-    'block[class*=centered]': CenteredBlock,
+    'block[kind=centered]': CenteredBlock,
   },
 };
 export default CENTERED_RENDERERS;

--- a/packages/landing-pages/src/CenteredBlock.tsx
+++ b/packages/landing-pages/src/CenteredBlock.tsx
@@ -57,7 +57,7 @@ export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
           )}
           {links && (
             <div className="mt-8 flex gap-4 items-center justify-center">
-              <MyST ast={links} />
+              <MyST ast={links} className="shrink-0" />
             </div>
           )}
         </div>
@@ -68,7 +68,7 @@ export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
 
 const CENTERED_RENDERERS: NodeRenderers = {
   block: {
-    'block[class~=centered]': CenteredBlock,
+    'block[class*=centered]': CenteredBlock,
   },
 };
 export default CENTERED_RENDERERS;

--- a/packages/landing-pages/src/CenteredBlock.tsx
+++ b/packages/landing-pages/src/CenteredBlock.tsx
@@ -19,13 +19,14 @@ export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
     const linksNode = selectAll('link,crossReference', rawBody);
     const subtitleNode = select('paragraph', head) as GenericParent | null;
     const headingNode = select('heading', head) as GenericParent | null;
-    const bodyNode = filter(
-      rawBody,
-      (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
-    )!.children;
+    const bodyNodes =
+      filter(
+        rawBody,
+        (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
+      )?.children ?? [];
 
     return {
-      body: bodyNode,
+      body: bodyNodes,
       links: linksNode,
       subtitle: subtitleNode,
       heading: headingNode,
@@ -57,7 +58,7 @@ export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
           )}
           {links && (
             <div className="mt-8 flex gap-4 items-center justify-center">
-              <MyST ast={links} className="shrink-0" />
+              <MyST ast={links} />
             </div>
           )}
         </div>

--- a/packages/landing-pages/src/CenteredBlock.tsx
+++ b/packages/landing-pages/src/CenteredBlock.tsx
@@ -18,7 +18,7 @@ export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
 
     const linksNode = selectAll('link,crossReference', rawBody);
     const subtitleNode = select('paragraph', head) as GenericParent | null;
-    const headingNode = select('heading[depth=2]', head) as GenericParent | null;
+    const headingNode = select('heading', head) as GenericParent | null;
     const bodyNode = filter(
       rawBody,
       (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),

--- a/packages/landing-pages/src/CenteredBlock.tsx
+++ b/packages/landing-pages/src/CenteredBlock.tsx
@@ -13,19 +13,24 @@ import { LandingBlock, type LandingBlockProps } from './LandingBlock.js';
 
 export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
   const { node } = props;
-  const { head, body: rawBody } = useMemo(() => splitByHeader(node), [node]);
+  const { body, links, subtitle, heading } = useMemo(() => {
+    const { head, body: rawBody } = splitByHeader(node);
 
-  const body = useMemo(
-    () =>
-      filter(
-        rawBody,
-        (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
-      )!.children,
-    [rawBody],
-  );
-  const links = useMemo(() => selectAll('link,crossReference', rawBody), [rawBody]);
-  const subtitle = useMemo(() => select('paragraph', head) as GenericParent | null, [head]);
-  const heading = useMemo(() => select('heading[depth=2]', head) as GenericParent | null, [head]);
+    const linksNode = selectAll('link,crossReference', rawBody);
+    const subtitleNode = select('paragraph', head) as GenericParent | null;
+    const headingNode = select('heading[depth=2]', head) as GenericParent | null;
+    const bodyNode = filter(
+      rawBody,
+      (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
+    )!.children;
+
+    return {
+      body: bodyNode,
+      links: linksNode,
+      subtitle: subtitleNode,
+      heading: headingNode,
+    };
+  }, [node]);
 
   if (!body) {
     return <InvalidBlock {...props} blockName="justified" />;

--- a/packages/landing-pages/src/CenteredBlock.tsx
+++ b/packages/landing-pages/src/CenteredBlock.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import type { GenericParent, GenericNode } from 'myst-common';
 import { MyST } from 'myst-to-react';
 
-import { select, selectAll } from 'unist-util-select';
+import { select, selectAll, matches } from 'unist-util-select';
 import { filter } from 'unist-util-filter';
 import type { NodeRenderers } from '@myst-theme/providers';
 
@@ -16,13 +16,14 @@ export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
   const { body, links, subtitle, heading } = useMemo(() => {
     const { head, body: rawBody } = splitByHeader(node);
 
-    const linksNode = selectAll('link,crossReference', rawBody);
+    const linksNode = selectAll('link[class*=button], crossReference[class*=button]', rawBody);
     const subtitleNode = select('paragraph', head) as GenericParent | null;
     const headingNode = select('heading', head) as GenericParent | null;
     const bodyNodes =
       filter(
         rawBody,
-        (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
+        (otherNode: GenericNode) =>
+          !matches('link[class*=button], crossReference[class*=button]', otherNode),
       )?.children ?? [];
 
     return {
@@ -34,7 +35,7 @@ export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
   }, [node]);
 
   if (!body) {
-    return <InvalidBlock {...props} blockName="justified" />;
+    return <InvalidBlock {...props} blockName="centered" />;
   }
   return (
     <LandingBlock {...props}>

--- a/packages/landing-pages/src/CenteredBlock.tsx
+++ b/packages/landing-pages/src/CenteredBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import type { GenericParent, GenericNode } from 'myst-common';
 import { MyST } from 'myst-to-react';
 
@@ -42,14 +42,14 @@ export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
       <div className="relative text-center">
         <div className="py-20 sm:py-28">
           {subtitle && (
-            <p className="font-semibold text-indigo-400 uppercase my-0">
+            <p className="my-0 font-semibold text-indigo-400 uppercase">
               <MyST ast={subtitle.children} />
             </p>
           )}
           {heading && (
             <BlockHeading
               node={heading}
-              className="text-5xl font-semibold tracking-tight mt-2 mb-0"
+              className="mt-2 mb-0 text-5xl font-semibold tracking-tight"
             />
           )}
           {body && (
@@ -58,7 +58,7 @@ export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
             </div>
           )}
           {links && (
-            <div className="mt-8 flex gap-4 items-center justify-center">
+            <div className="flex items-center justify-center gap-4 mt-8">
               <MyST ast={links} />
             </div>
           )}
@@ -68,9 +68,8 @@ export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
   );
 }
 
-const CENTERED_RENDERERS: NodeRenderers = {
+export const CENTERED_RENDERERS: NodeRenderers = {
   block: {
     'block[kind=centered]': CenteredBlock,
   },
 };
-export default CENTERED_RENDERERS;

--- a/packages/landing-pages/src/CenteredBlock.tsx
+++ b/packages/landing-pages/src/CenteredBlock.tsx
@@ -1,0 +1,69 @@
+import React, { useMemo } from 'react';
+import type { GenericParent, GenericNode } from 'myst-common';
+import { MyST } from 'myst-to-react';
+
+import { select, selectAll } from 'unist-util-select';
+import { filter } from 'unist-util-filter';
+import type { NodeRenderers } from '@myst-theme/providers';
+
+import { InvalidBlock } from './InvalidBlock.js';
+import { BlockHeading } from './BlockHeading.js';
+import { splitByHeader } from './utils.js';
+import { LandingBlock, type LandingBlockProps } from './LandingBlock.js';
+
+export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
+  const { node } = props;
+  const { head, body: rawBody } = useMemo(() => splitByHeader(node), [node]);
+
+  const body = useMemo(
+    () =>
+      filter(
+        rawBody,
+        (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
+      )!.children,
+    [rawBody],
+  );
+  const links = useMemo(() => selectAll('link,crossReference', rawBody), [rawBody]);
+  const subtitle = useMemo(() => select('paragraph', head) as GenericParent | null, [head]);
+  const heading = useMemo(() => select('heading[depth=2]', head) as GenericParent | null, [head]);
+
+  if (!body) {
+    return <InvalidBlock {...props} blockName="justified" />;
+  }
+  return (
+    <LandingBlock {...props}>
+      <div className="relative text-center">
+        <div className="py-20 sm:py-28">
+          {subtitle && (
+            <p className="font-semibold text-indigo-400 uppercase my-0">
+              <MyST ast={subtitle.children} />
+            </p>
+          )}
+          {heading && (
+            <BlockHeading
+              node={heading}
+              className="text-5xl font-semibold tracking-tight mt-2 mb-0"
+            />
+          )}
+          {body && (
+            <div className="mt-6">
+              <MyST ast={body} />
+            </div>
+          )}
+          {links && (
+            <div className="mt-8 flex gap-4 items-center justify-center">
+              <MyST ast={links} />
+            </div>
+          )}
+        </div>
+      </div>
+    </LandingBlock>
+  );
+}
+
+const CENTERED_RENDERERS: NodeRenderers = {
+  block: {
+    'block[class~=centered]': CenteredBlock,
+  },
+};
+export default CENTERED_RENDERERS;

--- a/packages/landing-pages/src/InvalidBlock.tsx
+++ b/packages/landing-pages/src/InvalidBlock.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { MyST } from 'myst-to-react';
+import { LandingBlock, type LandingBlockProps } from './LandingBlock.js';
+
+export function InvalidBlock(props: Omit<LandingBlockProps, 'children'> & { blockName: string }) {
+  const { node, blockName } = props;
+  return (
+    <LandingBlock {...props}>
+      <div className="relative" role="alert">
+        <div className="bg-red-500 text-white font-bold rounded-t px-4 py-2">
+          Invalid block <span className="font-mono">{blockName}</span>
+        </div>
+        <div className="border border-t-0 border-red-400 rounded-b ">
+          <div className="bg-red-100 text-red-700 px-4 py-3">
+            <p>This '{blockName}' block does not conform to the expected AST structure.</p>
+          </div>
+
+          <div className="px-4 py-3">
+            <MyST ast={node.children} />
+          </div>
+        </div>
+      </div>
+    </LandingBlock>
+  );
+}

--- a/packages/landing-pages/src/InvalidBlock.tsx
+++ b/packages/landing-pages/src/InvalidBlock.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MyST } from 'myst-to-react';
 import { LandingBlock, type LandingBlockProps } from './LandingBlock.js';
 
@@ -7,11 +6,11 @@ export function InvalidBlock(props: Omit<LandingBlockProps, 'children'> & { bloc
   return (
     <LandingBlock {...props}>
       <div className="relative" role="alert">
-        <div className="bg-red-500 text-white font-bold rounded-t px-4 py-2">
+        <div className="px-4 py-2 font-bold text-white bg-red-500 rounded-t">
           Invalid block <span className="font-mono">{blockName}</span>
         </div>
         <div className="border border-t-0 border-red-400 rounded-b ">
-          <div className="bg-red-100 text-red-700 px-4 py-3">
+          <div className="px-4 py-3 text-red-700 bg-red-100">
             <p>This '{blockName}' block does not conform to the expected AST structure.</p>
           </div>
 

--- a/packages/landing-pages/src/JustifiedBlock.tsx
+++ b/packages/landing-pages/src/JustifiedBlock.tsx
@@ -20,13 +20,14 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
     const linksNode = selectAll('link,crossReference', rawBody);
     const subtitleNode = select('paragraph', head) as GenericParent | null;
     const headingNode = select('heading', head) as GenericParent | null;
-    const bodyNode = filter(
-      rawBody,
-      (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
-    )!.children;
+    const bodyNodes =
+      filter(
+        rawBody,
+        (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
+      )?.children ?? [];
 
     return {
-      body: bodyNode,
+      body: bodyNodes,
       links: linksNode,
       subtitle: subtitleNode,
       heading: headingNode,
@@ -61,7 +62,7 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
           <div className="flex flex-col mt-8 lg:mt-0">
             {links && (
               <div className="flex flex-row gap-4 items-center">
-                <MyST ast={links} className="shrink-0" />
+                <MyST ast={links} />
               </div>
             )}
           </div>

--- a/packages/landing-pages/src/JustifiedBlock.tsx
+++ b/packages/landing-pages/src/JustifiedBlock.tsx
@@ -61,7 +61,7 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
           <div className="flex flex-col">
             {links && (
               <div className="flex flex-row mt-8 gap-4 items-center">
-                <MyST ast={links} />
+                <MyST ast={links} className="shrink-0" />
               </div>
             )}
           </div>
@@ -73,7 +73,7 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
 
 const JUSTIFIED_RENDERERS: NodeRenderers = {
   block: {
-    'block[class~=justified]': JustifiedBlock,
+    'block[class*=justified]': JustifiedBlock,
   },
 };
 export default JUSTIFIED_RENDERERS;

--- a/packages/landing-pages/src/JustifiedBlock.tsx
+++ b/packages/landing-pages/src/JustifiedBlock.tsx
@@ -19,7 +19,7 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
 
     const linksNode = selectAll('link,crossReference', rawBody);
     const subtitleNode = select('paragraph', head) as GenericParent | null;
-    const headingNode = select('heading[depth=2]', head) as GenericParent | null;
+    const headingNode = select('heading', head) as GenericParent | null;
     const bodyNode = filter(
       rawBody,
       (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),

--- a/packages/landing-pages/src/JustifiedBlock.tsx
+++ b/packages/landing-pages/src/JustifiedBlock.tsx
@@ -58,9 +58,9 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
               </div>
             )}
           </div>
-          <div className="flex flex-col">
+          <div className="flex flex-col mt-8 lg:mt-0">
             {links && (
-              <div className="flex flex-row mt-8 gap-4 items-center">
+              <div className="flex flex-row gap-4 items-center">
                 <MyST ast={links} className="shrink-0" />
               </div>
             )}

--- a/packages/landing-pages/src/JustifiedBlock.tsx
+++ b/packages/landing-pages/src/JustifiedBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import type { GenericParent, GenericNode } from 'myst-common';
 import { MyST } from 'myst-to-react';
 
@@ -42,7 +42,7 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
     <LandingBlock {...props}>
       <div className="py-20 sm:py-28 lg:px-8">
         {subtitle && (
-          <p className="font-semibold text-indigo-400 uppercase my-0">
+          <p className="my-0 font-semibold text-indigo-400 uppercase">
             <MyST ast={subtitle.children} />
           </p>
         )}
@@ -51,7 +51,7 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
             {heading && (
               <BlockHeading
                 node={heading}
-                className="text-5xl font-semibold tracking-tight mt-2 mb-0"
+                className="mt-2 mb-0 text-5xl font-semibold tracking-tight"
               />
             )}
             {body && (
@@ -62,7 +62,7 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
           </div>
           <div className="flex flex-col mt-8 lg:mt-0">
             {links && (
-              <div className="flex flex-row gap-4 items-center">
+              <div className="flex flex-row items-center gap-4">
                 <MyST ast={links} />
               </div>
             )}
@@ -73,9 +73,8 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
   );
 }
 
-const JUSTIFIED_RENDERERS: NodeRenderers = {
+export const JUSTIFIED_RENDERERS: NodeRenderers = {
   block: {
     'block[kind=justified]': JustifiedBlock,
   },
 };
-export default JUSTIFIED_RENDERERS;

--- a/packages/landing-pages/src/JustifiedBlock.tsx
+++ b/packages/landing-pages/src/JustifiedBlock.tsx
@@ -14,19 +14,24 @@ import { LandingBlock, type LandingBlockProps } from './LandingBlock.js';
 export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
   const { node } = props;
 
-  const { head, body: rawBody } = useMemo(() => splitByHeader(node), [node]);
+  const { body, links, subtitle, heading } = useMemo(() => {
+    const { head, body: rawBody } = splitByHeader(node);
 
-  const body = useMemo(
-    () =>
-      filter(
-        rawBody,
-        (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
-      )!.children,
-    [rawBody],
-  );
-  const links = useMemo(() => selectAll('link,crossReference', rawBody), [rawBody]);
-  const subtitle = useMemo(() => select('paragraph', head) as GenericParent | null, [head]);
-  const heading = useMemo(() => select('heading[depth=2]', head) as GenericParent | null, [head]);
+    const linksNode = selectAll('link,crossReference', rawBody);
+    const subtitleNode = select('paragraph', head) as GenericParent | null;
+    const headingNode = select('heading[depth=2]', head) as GenericParent | null;
+    const bodyNode = filter(
+      rawBody,
+      (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
+    )!.children;
+
+    return {
+      body: bodyNode,
+      links: linksNode,
+      subtitle: subtitleNode,
+      heading: headingNode,
+    };
+  }, [node]);
 
   if (!body) {
     return <InvalidBlock {...props} blockName="justified" />;

--- a/packages/landing-pages/src/JustifiedBlock.tsx
+++ b/packages/landing-pages/src/JustifiedBlock.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import type { GenericParent, GenericNode } from 'myst-common';
 import { MyST } from 'myst-to-react';
 
-import { select, selectAll } from 'unist-util-select';
+import { select, selectAll, matches } from 'unist-util-select';
 import { filter } from 'unist-util-filter';
 import type { NodeRenderers } from '@myst-theme/providers';
 
@@ -17,13 +17,14 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
   const { body, links, subtitle, heading } = useMemo(() => {
     const { head, body: rawBody } = splitByHeader(node);
 
-    const linksNode = selectAll('link,crossReference', rawBody);
+    const linksNode = selectAll('link[class*=button], crossReference[class*=button]', rawBody);
     const subtitleNode = select('paragraph', head) as GenericParent | null;
     const headingNode = select('heading', head) as GenericParent | null;
     const bodyNodes =
       filter(
         rawBody,
-        (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
+        (otherNode: GenericNode) =>
+          !matches('link[class*=button], crossReference[class*=button]', otherNode),
       )?.children ?? [];
 
     return {

--- a/packages/landing-pages/src/JustifiedBlock.tsx
+++ b/packages/landing-pages/src/JustifiedBlock.tsx
@@ -75,7 +75,7 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
 
 const JUSTIFIED_RENDERERS: NodeRenderers = {
   block: {
-    'block[class*=justified]': JustifiedBlock,
+    'block[kind=justified]': JustifiedBlock,
   },
 };
 export default JUSTIFIED_RENDERERS;

--- a/packages/landing-pages/src/JustifiedBlock.tsx
+++ b/packages/landing-pages/src/JustifiedBlock.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo } from 'react';
+import type { GenericParent, GenericNode } from 'myst-common';
+import { MyST } from 'myst-to-react';
+
+import { select, selectAll } from 'unist-util-select';
+import { filter } from 'unist-util-filter';
+import type { NodeRenderers } from '@myst-theme/providers';
+
+import { InvalidBlock } from './InvalidBlock.js';
+import { BlockHeading } from './BlockHeading.js';
+import { splitByHeader } from './utils.js';
+import { LandingBlock, type LandingBlockProps } from './LandingBlock.js';
+
+export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
+  const { node } = props;
+
+  const { head, body: rawBody } = useMemo(() => splitByHeader(node), [node]);
+
+  const body = useMemo(
+    () =>
+      filter(
+        rawBody,
+        (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
+      )!.children,
+    [rawBody],
+  );
+  const links = useMemo(() => selectAll('link,crossReference', rawBody), [rawBody]);
+  const subtitle = useMemo(() => select('paragraph', head) as GenericParent | null, [head]);
+  const heading = useMemo(() => select('heading[depth=2]', head) as GenericParent | null, [head]);
+
+  if (!body) {
+    return <InvalidBlock {...props} blockName="justified" />;
+  }
+  return (
+    <LandingBlock {...props}>
+      <div className="py-20 sm:py-28 lg:px-8">
+        {subtitle && (
+          <p className="font-semibold text-indigo-400 uppercase my-0">
+            <MyST ast={subtitle.children} />
+          </p>
+        )}
+        <div className="flex flex-col lg:content-center lg:justify-between lg:flex-row">
+          <div className="flex flex-col">
+            {heading && (
+              <BlockHeading
+                node={heading}
+                className="text-5xl font-semibold tracking-tight mt-2 mb-0"
+              />
+            )}
+            {body && (
+              <div className="mt-6">
+                <MyST ast={body} />
+              </div>
+            )}
+          </div>
+          <div className="flex flex-col">
+            {links && (
+              <div className="flex flex-row mt-8 gap-4 items-center">
+                <MyST ast={links} />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </LandingBlock>
+  );
+}
+
+const JUSTIFIED_RENDERERS: NodeRenderers = {
+  block: {
+    'block[class~=justified]': JustifiedBlock,
+  },
+};
+export default JUSTIFIED_RENDERERS;

--- a/packages/landing-pages/src/LandingBlock.tsx
+++ b/packages/landing-pages/src/LandingBlock.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import type { GenericParent } from 'myst-common';
 
 import { useGridSystemProvider } from '@myst-theme/providers';
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 export type LandingBlockProps = {
   node: GenericParent;
   className?: string;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 export function LandingBlock({ node, className, children }: LandingBlockProps) {

--- a/packages/landing-pages/src/LandingBlock.tsx
+++ b/packages/landing-pages/src/LandingBlock.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import type { GenericParent } from 'myst-common';
+
+import { useGridSystemProvider } from '@myst-theme/providers';
+import classNames from 'classnames';
+
+export type LandingBlockProps = {
+  node: GenericParent;
+  className?: string;
+  children: React.ReactNode;
+};
+
+export function LandingBlock({ node, className, children }: LandingBlockProps) {
+  const grid = useGridSystemProvider();
+  const { key } = node;
+
+  const subGrid = node.visibility === 'hide' ? '' : `${grid} subgrid-gap col-screen`;
+  const dataClassName = typeof node.data?.class === 'string' ? node.data?.class : undefined;
+  // Hide the subgrid if either the dataClass or the className exists and includes `col-`
+  const noSubGrid =
+    (dataClassName && dataClassName.includes('col-')) || (className && className.includes('col-'));
+
+  return (
+    <div
+      key={`block-${key}`}
+      id={key}
+      className={classNames('relative group/block', className, dataClassName, {
+        [subGrid]: !noSubGrid,
+        hidden: node.visibility === 'remove',
+      })}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/landing-pages/src/LandingBlock.tsx
+++ b/packages/landing-pages/src/LandingBlock.tsx
@@ -14,7 +14,7 @@ export function LandingBlock({ node, className, children }: LandingBlockProps) {
   const grid = useGridSystemProvider();
   const { key } = node;
 
-  const subGrid = node.visibility === 'hide' ? '' : `${grid} subgrid-gap col-screen`;
+  const subGrid = node.visibility === 'hide' ? '' : `${grid} subgrid-gap col-page [&>*]:col-page`;
   const dataClassName = typeof node.data?.class === 'string' ? node.data?.class : undefined;
   // Hide the subgrid if either the dataClass or the className exists and includes `col-`
   const noSubGrid =
@@ -24,7 +24,7 @@ export function LandingBlock({ node, className, children }: LandingBlockProps) {
     <div
       key={`block-${key}`}
       id={key}
-      className={classNames('relative group/block', className, dataClassName, {
+      className={classNames('relative group/block py-6', className, dataClassName, {
         [subGrid]: !noSubGrid,
         hidden: node.visibility === 'remove',
       })}

--- a/packages/landing-pages/src/LogoCloudBlock.tsx
+++ b/packages/landing-pages/src/LogoCloudBlock.tsx
@@ -3,7 +3,7 @@ import type { GenericNode } from 'myst-common';
 import { MyST } from 'myst-to-react';
 import type { NodeRenderers } from '@myst-theme/providers';
 
-import { select, selectAll } from 'unist-util-select';
+import { select, selectAll, matches } from 'unist-util-select';
 import { filter } from 'unist-util-filter';
 
 import { InvalidBlock } from './InvalidBlock.js';
@@ -15,11 +15,12 @@ export function LogoCloudBlock(props: Omit<LandingBlockProps, 'children'>) {
     const gridNode = select('grid', node);
     const rawBodyNode = filter(node, (child: GenericNode) => child.type !== 'grid')!;
 
-    const linksNode = selectAll('link,crossReference', rawBodyNode);
+    const linksNode = selectAll('link[class*=button], crossReference[class*=button]', rawBodyNode);
     const bodyNodes =
       filter(
         rawBodyNode,
-        (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
+        (otherNode: GenericNode) =>
+          !matches('link[class*=button], crossReference[class*=button]', otherNode),
       )?.children ?? [];
 
     return {

--- a/packages/landing-pages/src/LogoCloudBlock.tsx
+++ b/packages/landing-pages/src/LogoCloudBlock.tsx
@@ -41,7 +41,7 @@ export function LogoCloudBlock(props: Omit<LandingBlockProps, 'children'>) {
         {grid && <MyST ast={grid} />}
         {links && (
           <div className="mt-8 flex gap-4 items-center justify-center">
-            <MyST ast={links} />
+            <MyST ast={links} className="shrink-0" />
           </div>
         )}
       </div>
@@ -51,7 +51,7 @@ export function LogoCloudBlock(props: Omit<LandingBlockProps, 'children'>) {
 
 const LOGO_CLOUD_RENDERERS: NodeRenderers = {
   block: {
-    'block[class~=logo-cloud]': LogoCloudBlock,
+    'block[class*=logo-cloud]': LogoCloudBlock,
   },
 };
 export default LOGO_CLOUD_RENDERERS;

--- a/packages/landing-pages/src/LogoCloudBlock.tsx
+++ b/packages/landing-pages/src/LogoCloudBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import type { GenericNode } from 'myst-common';
 import { MyST } from 'myst-to-react';
 import type { NodeRenderers } from '@myst-theme/providers';
@@ -36,13 +36,13 @@ export function LogoCloudBlock(props: Omit<LandingBlockProps, 'children'>) {
 
   return (
     <LandingBlock {...props}>
-      <div className="text-center py-20 sm:py-28">
+      <div className="py-20 text-center sm:py-28">
         <div className="font-semibold">
           <MyST ast={body} />
         </div>
         {grid && <MyST ast={grid} />}
         {links && (
-          <div className="mt-8 flex gap-4 items-center justify-center">
+          <div className="flex items-center justify-center gap-4 mt-8">
             <MyST ast={links} />
           </div>
         )}
@@ -51,9 +51,8 @@ export function LogoCloudBlock(props: Omit<LandingBlockProps, 'children'>) {
   );
 }
 
-const LOGO_CLOUD_RENDERERS: NodeRenderers = {
+export const LOGO_CLOUD_RENDERERS: NodeRenderers = {
   block: {
     'block[kind=logo-cloud]': LogoCloudBlock,
   },
 };
-export default LOGO_CLOUD_RENDERERS;

--- a/packages/landing-pages/src/LogoCloudBlock.tsx
+++ b/packages/landing-pages/src/LogoCloudBlock.tsx
@@ -1,0 +1,55 @@
+import React, { useMemo } from 'react';
+import type { GenericNode } from 'myst-common';
+import { MyST } from 'myst-to-react';
+import type { NodeRenderers } from '@myst-theme/providers';
+
+import { select, selectAll } from 'unist-util-select';
+import { filter } from 'unist-util-filter';
+
+import { InvalidBlock } from './InvalidBlock.js';
+import { LandingBlock, type LandingBlockProps } from './LandingBlock.js';
+
+export function LogoCloudBlock(props: Omit<LandingBlockProps, 'children'>) {
+  const { node } = props;
+
+  const grid = useMemo(() => select('grid', node), [node]);
+  const rawBody = useMemo(
+    () => filter(node, (child: GenericNode) => child.type !== 'grid')!,
+    [node],
+  );
+  const body = useMemo(
+    () =>
+      filter(
+        rawBody,
+        (child: GenericNode) => child.type !== 'link' && child.type !== 'crossReference',
+      )!.children,
+    [rawBody],
+  );
+  const links = useMemo(() => selectAll('link,crossReference', rawBody), [rawBody]);
+  if (!grid) {
+    return <InvalidBlock {...props} blockName="logo-cloud" />;
+  }
+
+  return (
+    <LandingBlock {...props}>
+      <div className="text-center py-20 sm:py-28">
+        <div className="font-semibold">
+          <MyST ast={body} />
+        </div>
+        {grid && <MyST ast={grid} />}
+        {links && (
+          <div className="mt-8 flex gap-4 items-center justify-center">
+            <MyST ast={links} />
+          </div>
+        )}
+      </div>
+    </LandingBlock>
+  );
+}
+
+const LOGO_CLOUD_RENDERERS: NodeRenderers = {
+  block: {
+    'block[class~=logo-cloud]': LogoCloudBlock,
+  },
+};
+export default LOGO_CLOUD_RENDERERS;

--- a/packages/landing-pages/src/LogoCloudBlock.tsx
+++ b/packages/landing-pages/src/LogoCloudBlock.tsx
@@ -11,21 +11,23 @@ import { LandingBlock, type LandingBlockProps } from './LandingBlock.js';
 
 export function LogoCloudBlock(props: Omit<LandingBlockProps, 'children'>) {
   const { node } = props;
+  const { grid, body, links } = useMemo(() => {
+    const gridNode = select('grid', node);
+    const rawBodyNode = filter(node, (child: GenericNode) => child.type !== 'grid')!;
 
-  const grid = useMemo(() => select('grid', node), [node]);
-  const rawBody = useMemo(
-    () => filter(node, (child: GenericNode) => child.type !== 'grid')!,
-    [node],
-  );
-  const body = useMemo(
-    () =>
-      filter(
-        rawBody,
-        (child: GenericNode) => child.type !== 'link' && child.type !== 'crossReference',
-      )!.children,
-    [rawBody],
-  );
-  const links = useMemo(() => selectAll('link,crossReference', rawBody), [rawBody]);
+    const linksNode = selectAll('link,crossReference', rawBodyNode);
+    const bodyNode = filter(
+      rawBodyNode,
+      (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
+    )!.children;
+
+    return {
+      body: bodyNode,
+      grid: gridNode,
+      links: linksNode,
+    };
+  }, [node]);
+
   if (!grid) {
     return <InvalidBlock {...props} blockName="logo-cloud" />;
   }

--- a/packages/landing-pages/src/LogoCloudBlock.tsx
+++ b/packages/landing-pages/src/LogoCloudBlock.tsx
@@ -53,7 +53,7 @@ export function LogoCloudBlock(props: Omit<LandingBlockProps, 'children'>) {
 
 const LOGO_CLOUD_RENDERERS: NodeRenderers = {
   block: {
-    'block[class*=logo-cloud]': LogoCloudBlock,
+    'block[kind=logo-cloud]': LogoCloudBlock,
   },
 };
 export default LOGO_CLOUD_RENDERERS;

--- a/packages/landing-pages/src/LogoCloudBlock.tsx
+++ b/packages/landing-pages/src/LogoCloudBlock.tsx
@@ -16,13 +16,14 @@ export function LogoCloudBlock(props: Omit<LandingBlockProps, 'children'>) {
     const rawBodyNode = filter(node, (child: GenericNode) => child.type !== 'grid')!;
 
     const linksNode = selectAll('link,crossReference', rawBodyNode);
-    const bodyNode = filter(
-      rawBodyNode,
-      (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
-    )!.children;
+    const bodyNodes =
+      filter(
+        rawBodyNode,
+        (otherNode: GenericNode) => !['link', 'crossReference'].includes(otherNode.type),
+      )?.children ?? [];
 
     return {
-      body: bodyNode,
+      body: bodyNodes,
       grid: gridNode,
       links: linksNode,
     };
@@ -41,7 +42,7 @@ export function LogoCloudBlock(props: Omit<LandingBlockProps, 'children'>) {
         {grid && <MyST ast={grid} />}
         {links && (
           <div className="mt-8 flex gap-4 items-center justify-center">
-            <MyST ast={links} className="shrink-0" />
+            <MyST ast={links} />
           </div>
         )}
       </div>

--- a/packages/landing-pages/src/SplitImageBlock.tsx
+++ b/packages/landing-pages/src/SplitImageBlock.tsx
@@ -76,7 +76,7 @@ export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
 
 const SPLIT_IMAGE_RENDERERS: NodeRenderers = {
   block: {
-    'block[class*=split-image]': SplitImageBlock,
+    'block[kind=split-image]': SplitImageBlock,
   },
 };
 export default SPLIT_IMAGE_RENDERERS;

--- a/packages/landing-pages/src/SplitImageBlock.tsx
+++ b/packages/landing-pages/src/SplitImageBlock.tsx
@@ -42,11 +42,11 @@ export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
   return (
     <LandingBlock {...props}>
       <div className="relative bg-stone-900 dark:bg-stone-800 rounded-md">
-        <div className="lg:absolute lg:h-full lg:w-[calc(50%)] h-80 relative [&_img]:h-full [&_img]:w-full [&_img]:object-cover [&_img]:m-0 [&_picture]:m-0 [&_picture]:inline">
+        <div className="lg:absolute lg:h-full lg:w-[calc(50%)] md:absolute md:h-full md:w-[calc(100%/3)] h-80 relative [&_img]:h-full [&_img]:w-full [&_img]:object-cover [&_img]:m-0 [&_picture]:m-0 [&_picture]:inline">
           <MyST ast={image} />
         </div>
         <div className="relative py-24">
-          <div className="lg:ml-auto lg:w-[calc(50%)] lg:p-8 px-6 lg:pl-24">
+          <div className="lg:ml-auto lg:w-[calc(50%)] lg:p-8 lg:pl-24 md:ml-auto md:w-[calc(2*100%/3)] md:pl-16 md:p-8 px-6">
             {subtitle && (
               <p className=" prose prose-invert font-semibold text-indigo-400 uppercase my-0">
                 <MyST ast={subtitle.children} />

--- a/packages/landing-pages/src/SplitImageBlock.tsx
+++ b/packages/landing-pages/src/SplitImageBlock.tsx
@@ -40,29 +40,29 @@ export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
 
   return (
     <LandingBlock {...props}>
-      <div className="relative bg-stone-900 dark:bg-stone-800 rounded-md prose prose-invert">
+      <div className="relative bg-stone-900 dark:bg-stone-800 rounded-md">
         <div className="lg:absolute lg:h-full lg:w-[calc(50%)] h-80 relative [&_img]:h-full [&_img]:w-full [&_img]:object-cover [&_img]:m-0 [&_picture]:m-0 [&_picture]:inline">
           <MyST ast={image} />
         </div>
         <div className="relative py-24">
           <div className="lg:ml-auto lg:w-[calc(50%)] lg:p-8 px-6 lg:pl-24">
             {subtitle && (
-              <p className="font-semibold text-indigo-400 uppercase my-0">
+              <p className=" prose prose-invert font-semibold text-indigo-400 uppercase my-0">
                 <MyST ast={subtitle.children} />
               </p>
             )}
             {heading && (
               <BlockHeading
                 node={heading}
-                className="text-5xl font-semibold tracking-tight mt-2 mb-0"
+                className="text-white text-5xl font-semibold tracking-tight mt-2 mb-0"
               />
             )}
             <div className="mt-6">
-              <MyST ast={body} />
+              <MyST ast={body} className="prose prose-invert" />
             </div>
             {links && (
               <div className="mt-8 flex gap-4 items-center">
-                <MyST ast={links} />
+                <MyST ast={links} className="prose prose-invert" />
               </div>
             )}
           </div>

--- a/packages/landing-pages/src/SplitImageBlock.tsx
+++ b/packages/landing-pages/src/SplitImageBlock.tsx
@@ -74,7 +74,7 @@ export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
 
 const SPLIT_IMAGE_RENDERERS: NodeRenderers = {
   block: {
-    'block[class~=split-image]': SplitImageBlock,
+    'block[class*=split-image]': SplitImageBlock,
   },
 };
 export default SPLIT_IMAGE_RENDERERS;

--- a/packages/landing-pages/src/SplitImageBlock.tsx
+++ b/packages/landing-pages/src/SplitImageBlock.tsx
@@ -1,0 +1,73 @@
+import React, { useMemo } from 'react';
+import type { GenericParent, GenericNode } from 'myst-common';
+import { MyST } from 'myst-to-react';
+
+import { select, selectAll } from 'unist-util-select';
+import { filter } from 'unist-util-filter';
+import type { NodeRenderers } from '@myst-theme/providers';
+
+import { InvalidBlock } from './InvalidBlock.js';
+import { BlockHeading } from './BlockHeading.js';
+import { splitByHeader } from './utils.js';
+import { LandingBlock, type LandingBlockProps } from './LandingBlock.js';
+
+export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
+  const { node } = props;
+  const { head, body: rawBody } = useMemo(() => splitByHeader(node), [node]);
+  const image = useMemo(() => select('image', rawBody), [rawBody]);
+  const body = useMemo(
+    () =>
+      filter(
+        rawBody,
+        (otherNode: GenericNode) => !['link', 'crossReference', 'image'].includes(otherNode.type),
+      )!.children,
+    [rawBody],
+  );
+  const links = useMemo(() => selectAll('link,crossReference', rawBody), [rawBody]);
+  const subtitle = useMemo(() => select('paragraph', head) as GenericParent | null, [head]);
+  const heading = useMemo(() => select('heading[depth=2]', head) as GenericParent | null, [head]);
+
+  if (!image || !body) {
+    return <InvalidBlock {...props} blockName="split-image" />;
+  }
+
+  return (
+    <LandingBlock {...props}>
+      <div className="relative bg-stone-900 dark:bg-stone-800 text-white rounded-md">
+        <div className="lg:absolute lg:h-full lg:w-[calc(50%)] h-80 relative [&_img]:h-full [&_img]:w-full [&_img]:object-cover [&_img]:m-0 [&_picture]:m-0 [&_picture]:inline">
+          <MyST ast={image} />
+        </div>
+        <div className="relative py-24">
+          <div className="lg:ml-auto lg:w-[calc(50%)] lg:p-8 px-6 lg:pl-24">
+            {subtitle && (
+              <p className="font-semibold text-indigo-400 uppercase my-0">
+                <MyST ast={subtitle.children} />
+              </p>
+            )}
+            {heading && (
+              <BlockHeading
+                node={heading}
+                className="text-5xl text-white font-semibold tracking-tight mt-2 mb-0"
+              />
+            )}
+            <div className="mt-6 text-gray-300">
+              <MyST ast={body} />
+            </div>
+            {links && (
+              <div className="mt-8 flex gap-4 items-center">
+                <MyST ast={links} />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </LandingBlock>
+  );
+}
+
+const SPLIT_IMAGE_RENDERERS: NodeRenderers = {
+  block: {
+    'block[class~=split-image]': SplitImageBlock,
+  },
+};
+export default SPLIT_IMAGE_RENDERERS;

--- a/packages/landing-pages/src/SplitImageBlock.tsx
+++ b/packages/landing-pages/src/SplitImageBlock.tsx
@@ -18,7 +18,7 @@ export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
 
     const linksNode = selectAll('link,crossReference', rawBody);
     const subtitleNode = select('paragraph', head) as GenericParent | null;
-    const headingNode = select('heading[depth=2]', head) as GenericParent | null;
+    const headingNode = select('heading', head) as GenericParent | null;
     const imageNode = select('image', rawBody);
     const bodyNode = filter(
       rawBody,

--- a/packages/landing-pages/src/SplitImageBlock.tsx
+++ b/packages/landing-pages/src/SplitImageBlock.tsx
@@ -40,7 +40,7 @@ export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
 
   return (
     <LandingBlock {...props}>
-      <div className="relative bg-stone-900 dark:bg-stone-800 text-white rounded-md">
+      <div className="relative bg-stone-900 dark:bg-stone-800 rounded-md prose prose-invert">
         <div className="lg:absolute lg:h-full lg:w-[calc(50%)] h-80 relative [&_img]:h-full [&_img]:w-full [&_img]:object-cover [&_img]:m-0 [&_picture]:m-0 [&_picture]:inline">
           <MyST ast={image} />
         </div>
@@ -54,10 +54,10 @@ export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
             {heading && (
               <BlockHeading
                 node={heading}
-                className="text-5xl text-white font-semibold tracking-tight mt-2 mb-0"
+                className="text-5xl font-semibold tracking-tight mt-2 mb-0"
               />
             )}
-            <div className="mt-6 text-gray-300">
+            <div className="mt-6">
               <MyST ast={body} />
             </div>
             {links && (

--- a/packages/landing-pages/src/SplitImageBlock.tsx
+++ b/packages/landing-pages/src/SplitImageBlock.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import type { GenericParent, GenericNode } from 'myst-common';
 import { MyST } from 'myst-to-react';
 
-import { select, selectAll } from 'unist-util-select';
+import { select, selectAll, matches } from 'unist-util-select';
 import { filter } from 'unist-util-filter';
 import type { NodeRenderers } from '@myst-theme/providers';
 
@@ -23,7 +23,8 @@ export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
     const bodyNodes =
       filter(
         rawBody,
-        (otherNode: GenericNode) => !['link', 'crossReference', 'image'].includes(otherNode.type),
+        (otherNode: GenericNode) =>
+          !matches('link[class*=button], crossReference[class*=button], image', otherNode),
       )?.children ?? [];
 
     return {

--- a/packages/landing-pages/src/SplitImageBlock.tsx
+++ b/packages/landing-pages/src/SplitImageBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import type { GenericParent, GenericNode } from 'myst-common';
 import { MyST } from 'myst-to-react';
 
@@ -42,28 +42,28 @@ export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
 
   return (
     <LandingBlock {...props}>
-      <div className="relative bg-stone-900 dark:bg-stone-800 rounded-md">
+      <div className="relative rounded-md bg-stone-900 dark:bg-stone-800">
         <div className="lg:absolute lg:h-full lg:w-[calc(50%)] md:absolute md:h-full md:w-[calc(100%/3)] h-80 relative [&_img]:h-full [&_img]:w-full [&_img]:object-cover [&_img]:m-0 [&_picture]:m-0 [&_picture]:inline">
           <MyST ast={image} />
         </div>
         <div className="relative py-24">
           <div className="lg:ml-auto lg:w-[calc(50%)] lg:p-8 lg:pl-24 md:ml-auto md:w-[calc(2*100%/3)] md:pl-16 md:p-8 px-6">
             {subtitle && (
-              <p className=" prose prose-invert font-semibold text-indigo-400 uppercase my-0">
+              <p className="my-0 font-semibold prose text-indigo-400 uppercase  prose-invert">
                 <MyST ast={subtitle.children} />
               </p>
             )}
             {heading && (
               <BlockHeading
                 node={heading}
-                className="text-white text-5xl font-semibold tracking-tight mt-2 mb-0"
+                className="mt-2 mb-0 text-5xl font-semibold tracking-tight text-white"
               />
             )}
             <div className="mt-6">
               <MyST ast={body} className="prose prose-invert" />
             </div>
             {links && (
-              <div className="mt-8 flex gap-4 items-center">
+              <div className="flex items-center gap-4 mt-8">
                 <MyST ast={links} className="prose prose-invert" />
               </div>
             )}
@@ -74,9 +74,8 @@ export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
   );
 }
 
-const SPLIT_IMAGE_RENDERERS: NodeRenderers = {
+export const SPLIT_IMAGE_RENDERERS: NodeRenderers = {
   block: {
     'block[kind=split-image]': SplitImageBlock,
   },
 };
-export default SPLIT_IMAGE_RENDERERS;

--- a/packages/landing-pages/src/SplitImageBlock.tsx
+++ b/packages/landing-pages/src/SplitImageBlock.tsx
@@ -20,13 +20,14 @@ export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
     const subtitleNode = select('paragraph', head) as GenericParent | null;
     const headingNode = select('heading', head) as GenericParent | null;
     const imageNode = select('image', rawBody);
-    const bodyNode = filter(
-      rawBody,
-      (otherNode: GenericNode) => !['link', 'crossReference', 'image'].includes(otherNode.type),
-    )!.children;
+    const bodyNodes =
+      filter(
+        rawBody,
+        (otherNode: GenericNode) => !['link', 'crossReference', 'image'].includes(otherNode.type),
+      )?.children ?? [];
 
     return {
-      body: bodyNode,
+      body: bodyNodes,
       image: imageNode,
       links: linksNode,
       subtitle: subtitleNode,

--- a/packages/landing-pages/src/SplitImageBlock.tsx
+++ b/packages/landing-pages/src/SplitImageBlock.tsx
@@ -13,19 +13,26 @@ import { LandingBlock, type LandingBlockProps } from './LandingBlock.js';
 
 export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
   const { node } = props;
-  const { head, body: rawBody } = useMemo(() => splitByHeader(node), [node]);
-  const image = useMemo(() => select('image', rawBody), [rawBody]);
-  const body = useMemo(
-    () =>
-      filter(
-        rawBody,
-        (otherNode: GenericNode) => !['link', 'crossReference', 'image'].includes(otherNode.type),
-      )!.children,
-    [rawBody],
-  );
-  const links = useMemo(() => selectAll('link,crossReference', rawBody), [rawBody]);
-  const subtitle = useMemo(() => select('paragraph', head) as GenericParent | null, [head]);
-  const heading = useMemo(() => select('heading[depth=2]', head) as GenericParent | null, [head]);
+  const { image, body, links, subtitle, heading } = useMemo(() => {
+    const { head, body: rawBody } = splitByHeader(node);
+
+    const linksNode = selectAll('link,crossReference', rawBody);
+    const subtitleNode = select('paragraph', head) as GenericParent | null;
+    const headingNode = select('heading[depth=2]', head) as GenericParent | null;
+    const imageNode = select('image', rawBody);
+    const bodyNode = filter(
+      rawBody,
+      (otherNode: GenericNode) => !['link', 'crossReference', 'image'].includes(otherNode.type),
+    )!.children;
+
+    return {
+      body: bodyNode,
+      image: imageNode,
+      links: linksNode,
+      subtitle: subtitleNode,
+      heading: headingNode,
+    };
+  }, [node]);
 
   if (!image || !body) {
     return <InvalidBlock {...props} blockName="split-image" />;

--- a/packages/landing-pages/src/UnknownBlock.tsx
+++ b/packages/landing-pages/src/UnknownBlock.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { MyST } from 'myst-to-react';
+import { LandingBlock, type LandingBlockProps } from './LandingBlock.js';
+
+export function UnknownBlock(props: Omit<LandingBlockProps, 'children'> & { blockName: string }) {
+  const { node, blockName } = props;
+  return (
+    <LandingBlock {...props}>
+      <div className="relative" role="alert">
+        <div className="bg-red-500 text-white font-bold rounded-t px-4 py-2">
+          Unknown block <span className="font-mono">{blockName}</span>
+        </div>
+        <div className="border border-t-0 border-red-400 rounded-b px-4 py-3">
+          <MyST ast={node} />
+        </div>
+      </div>
+    </LandingBlock>
+  );
+}

--- a/packages/landing-pages/src/UnknownBlock.tsx
+++ b/packages/landing-pages/src/UnknownBlock.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MyST } from 'myst-to-react';
 import { LandingBlock, type LandingBlockProps } from './LandingBlock.js';
 
@@ -7,10 +6,10 @@ export function UnknownBlock(props: Omit<LandingBlockProps, 'children'> & { bloc
   return (
     <LandingBlock {...props}>
       <div className="relative" role="alert">
-        <div className="bg-red-500 text-white font-bold rounded-t px-4 py-2">
+        <div className="px-4 py-2 font-bold text-white bg-red-500 rounded-t">
           Unknown block <span className="font-mono">{blockName}</span>
         </div>
-        <div className="border border-t-0 border-red-400 rounded-b px-4 py-3">
+        <div className="px-4 py-3 border border-t-0 border-red-400 rounded-b">
           <MyST ast={node} />
         </div>
       </div>

--- a/packages/landing-pages/src/index.ts
+++ b/packages/landing-pages/src/index.ts
@@ -1,8 +1,8 @@
 import type { NodeRenderers } from '@myst-theme/providers';
-import SPLIT_IMAGE_RENDERERS from './SplitImageBlock.js';
-import CENTERED_RENDERERS from './CenteredBlock.js';
-import JUSTIFIED_RENDERERS from './JustifiedBlock.js';
-import LOGO_CLOUD_RENDERERS from './LogoCloudBlock.js';
+import { SPLIT_IMAGE_RENDERERS } from './SplitImageBlock.js';
+import { CENTERED_RENDERERS } from './CenteredBlock.js';
+import { JUSTIFIED_RENDERERS } from './JustifiedBlock.js';
+import { LOGO_CLOUD_RENDERERS } from './LogoCloudBlock.js';
 import { mergeRenderers } from '@myst-theme/providers';
 
 export * from './SplitImageBlock.js';

--- a/packages/landing-pages/src/index.ts
+++ b/packages/landing-pages/src/index.ts
@@ -10,10 +10,9 @@ export * from './CenteredBlock.js';
 export * from './JustifiedBlock.js';
 export * from './LogoCloudBlock.js';
 
-const BLOCK_RENDERERS: NodeRenderers = mergeRenderers([
+export const LANDING_PAGE_RENDERERS: NodeRenderers = mergeRenderers([
   SPLIT_IMAGE_RENDERERS,
   CENTERED_RENDERERS,
   JUSTIFIED_RENDERERS,
   LOGO_CLOUD_RENDERERS,
 ]);
-export default BLOCK_RENDERERS;

--- a/packages/landing-pages/src/index.ts
+++ b/packages/landing-pages/src/index.ts
@@ -1,0 +1,14 @@
+import type { NodeRenderers } from '@myst-theme/providers';
+import SPLIT_IMAGE_RENDERERS from './SplitImageBlock.js';
+import CENTERED_RENDERERS from './CenteredBlock.js';
+import JUSTIFIED_RENDERERS from './JustifiedBlock.js';
+import LOGO_CLOUD_RENDERERS from './LogoCloudBlock.js';
+import { mergeRenderers } from '@myst-theme/providers';
+
+const BLOCK_RENDERERS: NodeRenderers = mergeRenderers([
+  SPLIT_IMAGE_RENDERERS,
+  CENTERED_RENDERERS,
+  JUSTIFIED_RENDERERS,
+  LOGO_CLOUD_RENDERERS,
+]);
+export default BLOCK_RENDERERS;

--- a/packages/landing-pages/src/index.ts
+++ b/packages/landing-pages/src/index.ts
@@ -5,6 +5,11 @@ import JUSTIFIED_RENDERERS from './JustifiedBlock.js';
 import LOGO_CLOUD_RENDERERS from './LogoCloudBlock.js';
 import { mergeRenderers } from '@myst-theme/providers';
 
+export * from './SplitImageBlock.js';
+export * from './CenteredBlock.js';
+export * from './JustifiedBlock.js';
+export * from './LogoCloudBlock.js';
+
 const BLOCK_RENDERERS: NodeRenderers = mergeRenderers([
   SPLIT_IMAGE_RENDERERS,
   CENTERED_RENDERERS,

--- a/packages/landing-pages/src/utils.ts
+++ b/packages/landing-pages/src/utils.ts
@@ -1,13 +1,16 @@
 import type { GenericParent } from 'myst-common';
 
-export function splitByHeader(mdast: GenericParent): {
+export function splitByHeader(
+  mdast: GenericParent,
+  depth?: number | undefined,
+): {
   head: GenericParent | undefined;
   body: GenericParent;
 } {
   let i;
   for (i = 0; i < mdast.children.length; i++) {
     const node = mdast.children[i];
-    if (node.type === 'heading' && node.depth === 2) {
+    if (node.type === 'heading' && (depth === undefined || node.depth === depth)) {
       break;
     }
   }

--- a/packages/landing-pages/src/utils.ts
+++ b/packages/landing-pages/src/utils.ts
@@ -1,0 +1,25 @@
+import type { GenericParent } from 'myst-common';
+
+export function splitByHeader(mdast: GenericParent): {
+  head: GenericParent | undefined;
+  body: GenericParent;
+} {
+  let i;
+  for (i = 0; i < mdast.children.length; i++) {
+    const node = mdast.children[i];
+    if (node.type === 'heading' && node.depth === 2) {
+      break;
+    }
+  }
+  if (i === mdast.children.length) {
+    return {
+      head: undefined,
+      body: { type: 'block', children: mdast.children as any },
+    };
+  } else {
+    return {
+      head: { type: 'block', children: mdast.children.slice(0, i + 1) as any },
+      body: { type: 'block', children: mdast.children.slice(i + 1) as any },
+    };
+  }
+}

--- a/packages/landing-pages/tsconfig.json
+++ b/packages/landing-pages/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig/react-library.json",
+  "include": ["src"],
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "paths": {
+      "~/*": ["./src/*"]
+    },
+    "outDir": "dist"
+  }
+}

--- a/packages/myst-to-react/src/hashLink.tsx
+++ b/packages/myst-to-react/src/hashLink.tsx
@@ -57,6 +57,7 @@ export function HashLink({
   scrollBehavior,
   historyState,
   focusTarget,
+  noWidth,
 }: {
   id?: string;
   kind?: string;
@@ -66,6 +67,8 @@ export function HashLink({
   canSelectText?: boolean;
   className?: string;
   hideInPopup?: boolean;
+  /** Ensures that when centered it doesn't take up space */
+  noWidth?: boolean;
 } & HashLinkBehavior) {
   const { inCrossRef } = useXRefState();
   if (inCrossRef || !id) {
@@ -82,13 +85,18 @@ export function HashLink({
   };
   return (
     <a
-      className={classNames('no-underline text-inherit hover:text-inherit', className, {
-        'select-none': !canSelectText,
-        'transition-opacity opacity-0 focus:opacity-100 group-hover:opacity-70': hover === true,
-        '[@media(hover:hover)]:transition-opacity [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:focus:opacity-100 [@media(hover:hover)]:group-hover:opacity-70':
-          hover === 'desktop',
-        'hover:underline': !hover,
-      })}
+      className={classNames(
+        'no-underline text-inherit hover:text-inherit',
+        { 'inline-block w-0 px-0 translate-x-[10px]': noWidth === true },
+        className,
+        {
+          'select-none': !canSelectText,
+          'transition-opacity opacity-0 focus:opacity-100 group-hover:opacity-70': hover === true,
+          '[@media(hover:hover)]:transition-opacity [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:focus:opacity-100 [@media(hover:hover)]:group-hover:opacity-70':
+            hover === 'desktop',
+          'hover:underline': !hover,
+        },
+      )}
       onClick={scroll}
       href={`#${id}`}
       title={title}

--- a/packages/myst-to-react/src/heading.tsx
+++ b/packages/myst-to-react/src/heading.tsx
@@ -13,7 +13,7 @@ const Heading: NodeRenderer = ({ node, className }) => {
       <span className="heading-text">
         <MyST ast={node.children} />
       </span>
-      <HashLink id={id} kind="Section" className="px-2 font-normal" hover hideInPopup />
+      <HashLink id={id} kind="Section" className="font-normal" hover hideInPopup noWidth />
     </>
   );
   // The `heading-text` class is picked up in the Outline to select without the enumerator and "#" link

--- a/styles/button.css
+++ b/styles/button.css
@@ -2,7 +2,7 @@ a.button {
   @apply px-4 py-2 font-bold rounded no-underline;
 }
 a.button {
-  @apply text-white bg-blue-500;
+  @apply text-white bg-blue-500 whitespace-nowrap;
 }
 a.button:hover {
   @apply bg-blue-700;

--- a/styles/index.js
+++ b/styles/index.js
@@ -7,6 +7,7 @@ const content = [
   'node_modules/@myst-theme/frontmatter/{src,dist}/**/*.{js,ts,jsx,tsx}',
   'node_modules/@myst-theme/jupyter/{src,dist}/**/*.{js,ts,jsx,tsx}',
   'node_modules/@myst-theme/icons/{src,dist}/**/*.{js,ts,jsx,tsx}',
+  'node_modules/@myst-theme/landing-pages/{src,dist}/**/*.{js,ts,jsx,tsx}',
   // Duplicate the above in case this is in a submodule
   '../../packages/myst-to-react/{src,dist}/**/*.{js,ts,jsx,tsx}',
   '../../packages/myst-demo/{src,dist}/**/*.{js,ts,jsx,tsx}',
@@ -14,6 +15,7 @@ const content = [
   '../../packages/frontmatter/{src,dist}/**/*.{js,ts,jsx,tsx}',
   '../../packages/jupyter/{src,dist}/**/*.{js,ts,jsx,tsx}',
   '../../packages/icons/{src,dist}/**/*.{js,ts,jsx,tsx}',
+  '../../packages/landing-pages/{src,dist}/**/*.{js,ts,jsx,tsx}',
 ];
 
 const themeExtensions = {

--- a/themes/book/app/root.tsx
+++ b/themes/book/app/root.tsx
@@ -19,10 +19,16 @@ import { SearchFactoryProvider, mergeRenderers } from '@myst-theme/providers';
 import type { NodeRenderers } from '@myst-theme/providers';
 import type { ISearch, MystSearchIndex } from '@myst-theme/search';
 import { SEARCH_ATTRIBUTES_ORDERED } from '@myst-theme/search';
+
 import { JUPYTER_RENDERERS } from '@myst-theme/jupyter';
+import LANDING_PAGE_RENDERERS from '@myst-theme/landing-pages';
 import { useCallback } from 'react';
 
-const RENDERERS: NodeRenderers = mergeRenderers([defaultRenderers, JUPYTER_RENDERERS]);
+const RENDERERS: NodeRenderers = mergeRenderers([
+  LANDING_PAGE_RENDERERS,
+  JUPYTER_RENDERERS,
+  defaultRenderers,
+]);
 
 export const meta: V2_MetaFunction<typeof loader> = ({ data }) => {
   return getMetaTagsForSite({

--- a/themes/book/app/root.tsx
+++ b/themes/book/app/root.tsx
@@ -21,7 +21,7 @@ import type { ISearch, MystSearchIndex } from '@myst-theme/search';
 import { SEARCH_ATTRIBUTES_ORDERED } from '@myst-theme/search';
 
 import { JUPYTER_RENDERERS } from '@myst-theme/jupyter';
-import LANDING_PAGE_RENDERERS from '@myst-theme/landing-pages';
+import { LANDING_PAGE_RENDERERS } from '@myst-theme/landing-pages';
 import { useCallback } from 'react';
 
 const RENDERERS: NodeRenderers = mergeRenderers([

--- a/themes/book/app/root.tsx
+++ b/themes/book/app/root.tsx
@@ -25,9 +25,9 @@ import LANDING_PAGE_RENDERERS from '@myst-theme/landing-pages';
 import { useCallback } from 'react';
 
 const RENDERERS: NodeRenderers = mergeRenderers([
-  LANDING_PAGE_RENDERERS,
-  JUPYTER_RENDERERS,
   defaultRenderers,
+  JUPYTER_RENDERERS,
+  LANDING_PAGE_RENDERERS,
 ]);
 
 export const meta: V2_MetaFunction<typeof loader> = ({ data }) => {

--- a/themes/book/app/routes/_index.tsx
+++ b/themes/book/app/routes/_index.tsx
@@ -7,26 +7,10 @@ import {
 import type { LinksFunction, LoaderFunction, V2_MetaFunction } from '@remix-run/node';
 import { json, redirect } from '@remix-run/node';
 import { getConfig, getPage } from '~/utils/loaders.server';
-import type { SiteManifest } from 'myst-config';
+import Page from './$';
+import { SiteManifest } from 'myst-config';
 import { getProject } from '@myst-theme/common';
 
-import {} from '@remix-run/node';
-import { type PageLoader } from '@myst-theme/common';
-import { useOutlineHeight, useSidebarHeight, PrimaryNavigation, TopNav } from '@myst-theme/site';
-import { useLoaderData } from '@remix-run/react';
-import {
-  TabStateProvider,
-  UiStateProvider,
-  useBaseurl,
-  useSiteManifest,
-  useThemeTop,
-  ProjectProvider,
-} from '@myst-theme/providers';
-import { MadeWithMyst } from '@myst-theme/icons';
-import DefaultPageRoute from './$';
-import { ArticlePage } from '../components/ArticlePage.js';
-import { ComputeOptionsProvider, ThebeLoaderAndServer } from '@myst-theme/jupyter';
-import type { TemplateOptions } from '../types.js';
 type ManifestProject = Required<SiteManifest>['projects'][0];
 
 export const meta: V2_MetaFunction<typeof loader> = ({ data, location }) => {
@@ -58,96 +42,4 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   return json({ config, page, project });
 };
 
-function ArticlePageAndNavigationInternal({
-  children,
-  hide_toc,
-  hideSearch,
-  projectSlug,
-  inset = 20, // begin text 20px from the top (aligned with menu)
-}: {
-  hide_toc?: boolean;
-  hideSearch?: boolean;
-  projectSlug?: string;
-  children: React.ReactNode;
-  inset?: number;
-}) {
-  const top = useThemeTop();
-  const { container, toc } = useSidebarHeight(top, inset);
-  return (
-    <>
-      <TopNav hideToc={hide_toc} hideSearch={hideSearch} />
-      <PrimaryNavigation
-        sidebarRef={toc}
-        hide_toc={hide_toc}
-        footer={<MadeWithMyst />}
-        projectSlug={projectSlug}
-      />
-      <TabStateProvider>
-        <article
-          ref={container}
-          className="article content article-grid grid-gap"
-          // article does not neet to get top as it is in the page flow (z-0)
-          // style={{ marginTop: top }}
-        >
-          {children}
-        </article>
-      </TabStateProvider>
-    </>
-  );
-}
-
-function ArticlePageAndNavigation({
-  children,
-  hide_toc,
-  hideSearch,
-  projectSlug,
-  inset = 20, // begin text 20px from the top (aligned with menu)
-}: {
-  hide_toc?: boolean;
-  hideSearch?: boolean;
-  projectSlug?: string;
-  children: React.ReactNode;
-  inset?: number;
-}) {
-  return (
-    <UiStateProvider>
-      <ArticlePageAndNavigationInternal
-        children={children}
-        hide_toc={hide_toc}
-        hideSearch={hideSearch}
-        projectSlug={projectSlug}
-        inset={inset}
-      />
-    </UiStateProvider>
-  );
-}
-
-export default function Page() {
-  const siteDesign: TemplateOptions =
-    (useSiteManifest() as SiteManifest & TemplateOptions)?.options ?? {};
-
-  const { container } = useOutlineHeight();
-  const data = useLoaderData() as { page: PageLoader; project: ManifestProject };
-  const baseurl = useBaseurl();
-  const pageDesign: TemplateOptions = (data.page.frontmatter as any)?.site ?? {};
-  const { hide_search, hide_footer_links } = {
-    ...siteDesign,
-    ...pageDesign,
-  };
-  return (
-    <ArticlePageAndNavigation hide_toc hideSearch={hide_search} projectSlug={data.page.project}>
-      {/* <ProjectProvider project={project}> */}
-      <ProjectProvider>
-        <ComputeOptionsProvider
-          features={{ notebookCompute: true, figureCompute: true, launchBinder: false }}
-        >
-          <ThebeLoaderAndServer baseurl={baseurl}>
-            <main ref={container} className="landing-page article-grid subgrid-gap col-screen">
-              <ArticlePage article={data.page} hide_all_footer_links={hide_footer_links} />
-            </main>
-          </ThebeLoaderAndServer>
-        </ComputeOptionsProvider>
-      </ProjectProvider>
-    </ArticlePageAndNavigation>
-  );
-}
+export default Page;

--- a/themes/book/app/routes/_index.tsx
+++ b/themes/book/app/routes/_index.tsx
@@ -7,10 +7,26 @@ import {
 import type { LinksFunction, LoaderFunction, V2_MetaFunction } from '@remix-run/node';
 import { json, redirect } from '@remix-run/node';
 import { getConfig, getPage } from '~/utils/loaders.server';
-import Page from './$';
-import { SiteManifest } from 'myst-config';
+import type { SiteManifest } from 'myst-config';
 import { getProject } from '@myst-theme/common';
 
+import {} from '@remix-run/node';
+import { type PageLoader } from '@myst-theme/common';
+import { useOutlineHeight, useSidebarHeight, PrimaryNavigation, TopNav } from '@myst-theme/site';
+import { useLoaderData } from '@remix-run/react';
+import {
+  TabStateProvider,
+  UiStateProvider,
+  useBaseurl,
+  useSiteManifest,
+  useThemeTop,
+  ProjectProvider,
+} from '@myst-theme/providers';
+import { MadeWithMyst } from '@myst-theme/icons';
+import DefaultPageRoute from './$';
+import { ArticlePage } from '../components/ArticlePage.js';
+import { ComputeOptionsProvider, ThebeLoaderAndServer } from '@myst-theme/jupyter';
+import type { TemplateOptions } from '../types.js';
 type ManifestProject = Required<SiteManifest>['projects'][0];
 
 export const meta: V2_MetaFunction<typeof loader> = ({ data, location }) => {
@@ -42,4 +58,96 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   return json({ config, page, project });
 };
 
-export default Page;
+function ArticlePageAndNavigationInternal({
+  children,
+  hide_toc,
+  hideSearch,
+  projectSlug,
+  inset = 20, // begin text 20px from the top (aligned with menu)
+}: {
+  hide_toc?: boolean;
+  hideSearch?: boolean;
+  projectSlug?: string;
+  children: React.ReactNode;
+  inset?: number;
+}) {
+  const top = useThemeTop();
+  const { container, toc } = useSidebarHeight(top, inset);
+  return (
+    <>
+      <TopNav hideToc={hide_toc} hideSearch={hideSearch} />
+      <PrimaryNavigation
+        sidebarRef={toc}
+        hide_toc={hide_toc}
+        footer={<MadeWithMyst />}
+        projectSlug={projectSlug}
+      />
+      <TabStateProvider>
+        <article
+          ref={container}
+          className="article content article-grid grid-gap"
+          // article does not neet to get top as it is in the page flow (z-0)
+          // style={{ marginTop: top }}
+        >
+          {children}
+        </article>
+      </TabStateProvider>
+    </>
+  );
+}
+
+function ArticlePageAndNavigation({
+  children,
+  hide_toc,
+  hideSearch,
+  projectSlug,
+  inset = 20, // begin text 20px from the top (aligned with menu)
+}: {
+  hide_toc?: boolean;
+  hideSearch?: boolean;
+  projectSlug?: string;
+  children: React.ReactNode;
+  inset?: number;
+}) {
+  return (
+    <UiStateProvider>
+      <ArticlePageAndNavigationInternal
+        children={children}
+        hide_toc={hide_toc}
+        hideSearch={hideSearch}
+        projectSlug={projectSlug}
+        inset={inset}
+      />
+    </UiStateProvider>
+  );
+}
+
+export default function Page() {
+  const siteDesign: TemplateOptions =
+    (useSiteManifest() as SiteManifest & TemplateOptions)?.options ?? {};
+
+  const { container } = useOutlineHeight();
+  const data = useLoaderData() as { page: PageLoader; project: ManifestProject };
+  const baseurl = useBaseurl();
+  const pageDesign: TemplateOptions = (data.page.frontmatter as any)?.site ?? {};
+  const { hide_search, hide_footer_links } = {
+    ...siteDesign,
+    ...pageDesign,
+  };
+  return (
+    <ArticlePageAndNavigation hide_toc hideSearch={hide_search} projectSlug={data.page.project}>
+      {/* <ProjectProvider project={project}> */}
+      <ProjectProvider>
+        <ComputeOptionsProvider
+          features={{ notebookCompute: true, figureCompute: true, launchBinder: false }}
+        >
+          <ThebeLoaderAndServer baseurl={baseurl}>
+            <main ref={container} className="landing-page article-grid subgrid-gap col-screen">
+              <ArticlePage article={data.page} hide_all_footer_links={hide_footer_links} />
+            </main>
+          </ThebeLoaderAndServer>
+        </ComputeOptionsProvider>
+      </ProjectProvider>
+    </ArticlePageAndNavigation>
+  );
+}

--- a/themes/book/package.json
+++ b/themes/book/package.json
@@ -22,6 +22,7 @@
     "@myst-theme/site": "^0.14.1",
     "@myst-theme/common": "^0.14.1",
     "@myst-theme/styles": "^0.14.1",
+    "@myst-theme/landing-pages": "^0.0.0",
     "@remix-run/node": "~1.17.0",
     "@remix-run/react": "~1.17.0",
     "@remix-run/vercel": "~1.17.0",

--- a/themes/book/styles/app.css
+++ b/themes/book/styles/app.css
@@ -1,1 +1,11 @@
 @import '@myst-theme/styles';
+
+.landing-page .article-grid > *,
+.landing-page .article-left-grid > *,
+.landing-page .article-center-grid > * {
+  grid-column: page;
+}
+
+.landing-page {
+  @apply gap-y-6;
+}

--- a/themes/book/styles/app.css
+++ b/themes/book/styles/app.css
@@ -1,11 +1,1 @@
 @import '@myst-theme/styles';
-
-.landing-page .article-grid > *,
-.landing-page .article-left-grid > *,
-.landing-page .article-center-grid > * {
-  grid-column: page;
-}
-
-.landing-page {
-  @apply gap-y-6;
-}


### PR DESCRIPTION
## Overview
This PR is an implementation of an MVP for _landing page_ blocks to the book theme. It is being driven by the Product and Services team at 2i2c, which is tracking the work under https://github.com/2i2c-org/infrastructure/issues/5482

The goal here is to allow _communities_ to opt-in to welcoming their audience on the home page. The design requirements for the landing page are therefore different to regular page routes. This PR follows some scoping work to figure out what a potential design might look like. The exploration process can be viewed by following the chain of issues in the 2i2c infrastructure issue above.

An example website with the proper metadata (and patched theme deployment) can be found at https://2i2c.org/cryocloud-landing-demo/.

## Block Types

- `split-image` — a hero heading with an `object-fit` image cover, supporting body, links, and subtitle.
- `centered` — a heading with optional subtitle, links, and body that is centered on the page
- `justified` — a heading with optional subtitle, links, and body that is left-justified on the page
- `logo-cloud` — a small enhancement upon a CSS grid that centers the text and adds a `semibold` font style

## Design Points
- Block-level landing pages feel "simple", and constrained. It feels like we should be aiming for simple and good-enough rather than enabling arbitrary web pages. Therefore, blocks do not need to be nested.
- As blocks are non-nestable, it does not make much sense to use directives. Instead, this PR uses block annotation. In the future, we could unify block attributes with MEP#003 to support e.g.
   ```
   +++ {.image-split}
   ```
- This is not an exhaustive set of landing-page blocks, and drops the distinction between headers and CTAs. In this PR, CTAs are just headers with buttons and/or links. 

## Questions for Reviewers
- [ ] What should we do about the frontmatter title and subtitle? I want to suggest that we don't use them, but then how do we stop e.g. `h1` in the split-image card from being swallowed? I know that this is already an active discussion topic.

## Screenshots
![image](https://github.com/user-attachments/assets/5197ee48-35f4-41f9-822e-e6f19ee14082)

## Related

- https://github.com/executablebooks/sphinx-book-theme/issues/162
- https://github.com/executablebooks/sphinx-book-theme/pull/557
