### PR TITLE
🔗 Update static links in parts in config

### DIFF
--- a/.changeset/silly-deers-trade.md
+++ b/.changeset/silly-deers-trade.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/common': patch
+---
+
+Update static links in parts in config


### PR DESCRIPTION
Image urls were failing if they were in a site/project `part` - this is because the links were not getting rewritten for the CDN. This PR adds those links to the rewrite function.