### PR TITLE
holoviews support: fix output path fetching

### DIFF
--- a/.changeset/itchy-pugs-teach.md
+++ b/.changeset/itchy-pugs-teach.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/jupyter': patch
+---
+
+Fix minified mimebundle fetching for the case of multiple minified bundles in a single output

--- a/packages/jupyter/src/hooks.ts
+++ b/packages/jupyter/src/hooks.ts
@@ -34,6 +34,7 @@ async function fetcher(url: string) {
         // pass
       }
     }
+    console.log('fetcher', url, content);
     return { content } as any;
   }
   throw new Error(`Content returned with status ${resp.status}.`);
@@ -52,8 +53,8 @@ export function useLongContent(
   return { data, error };
 }
 
-const arrayFetcher = (...urls: string[][]) => {
-  return Promise.all(urls.map((url) => fetcher(url[0])));
+const arrayFetcher = (urls: string[]) => {
+  return Promise.all(urls.map((url) => fetcher(url)));
 };
 
 type ObjectWithPath = MinifiedErrorOutput | MinifiedStreamOutput | MinifiedMimePayload;
@@ -89,10 +90,9 @@ export function useFetchAnyTruncatedContent(outputs: MinifiedOutput[]): {
     }
   });
 
-  const { data, error } = useSWRImmutable<LongContent[]>(
-    itemsWithPaths.map(({ path }) => path),
-    arrayFetcher as any,
-  );
+  const paths = itemsWithPaths.map(({ path }) => path);
+
+  const { data, error } = useSWRImmutable<LongContent[]>(paths, arrayFetcher as any);
 
   data?.forEach(({ content }, idx) => {
     const obj = itemsWithPaths[idx];


### PR DESCRIPTION
This fixes a bug in how outputs with multiple minified mime bundles (with path properties) were having their mime bundles properly fetched and rebuilt, resulting in some mimebundles being stripped.

This had a direct effect on holoviews (bokeh, plotly) which this PR fixes (related: #527)

This bug could have also been responsible for other unexpected behaviour where ever the multiple minified mimebundles are present.
