### PR TITLE
🧱 Only apply grid system to outer `<MyST>` component

### DIFF
--- a/packages/jupyter/src/block.tsx
+++ b/packages/jupyter/src/block.tsx
@@ -7,7 +7,7 @@ import {
   NotebookRunCell,
   NotebookRunCellSpinnerOnly,
 } from './controls/index.js';
-import { useGridSystemProvider, usePageKind } from '@myst-theme/providers';
+import { usePageKind } from '@myst-theme/providers';
 import type { NodeRenderers, NodeRenderer } from '@myst-theme/providers';
 
 export function NotebookBlock({
@@ -20,18 +20,12 @@ export function NotebookBlock({
   className?: string;
 }) {
   const pageKind = usePageKind();
-  const grid = useGridSystemProvider();
-  const subGrid = node.visibility === 'hide' ? '' : `${grid} subgrid-gap col-screen`;
   const dataClassName = typeof node.data?.class === 'string' ? node.data?.class : undefined;
-  // Hide the subgrid if either the dataClass or the className exists and includes `col-`
-  const noSubGrid =
-    (dataClassName && dataClassName.includes('col-')) || (className && className.includes('col-'));
   const block = (
     <div
       key={`block-${id}`}
       id={id}
       className={classNames('relative group/block', className, dataClassName, {
-        [subGrid]: !noSubGrid,
         hidden: node.visibility === 'remove',
       })}
     >

--- a/packages/myst-to-react/src/block.tsx
+++ b/packages/myst-to-react/src/block.tsx
@@ -2,8 +2,15 @@ import { Details } from './dropdown.js';
 import { MyST } from './MyST.js';
 import type { GenericParent } from 'myst-common';
 import classNames from 'classnames';
-import { useGridSystemProvider } from '@myst-theme/providers';
 import type { NodeRenderer } from '@myst-theme/providers';
+
+export function blockGridClassName(node: GenericParent, grid: string): string {
+  const subGrid = node.visibility === 'hide' ? '' : `${grid} subgrid-gap col-screen`;
+  const dataClassName = typeof node.data?.class === 'string' ? node.data?.class : undefined;
+  // Hide the subgrid if either the dataClass or the className exists and includes `col-`
+  const noSubGrid = dataClassName && dataClassName.includes('col-');
+  return classNames({ [subGrid]: !noSubGrid });
+}
 
 export function Block({
   id,
@@ -14,18 +21,12 @@ export function Block({
   node: GenericParent;
   className?: string;
 }) {
-  const grid = useGridSystemProvider();
-  const subGrid = node.visibility === 'hide' ? '' : `${grid} subgrid-gap col-screen`;
   const dataClassName = typeof node.data?.class === 'string' ? node.data?.class : undefined;
-  // Hide the subgrid if either the dataClass or the className exists and includes `col-`
-  const noSubGrid =
-    (dataClassName && dataClassName.includes('col-')) || (className && className.includes('col-'));
   const block = (
     <div
       key={`block-${id}`}
       id={id}
       className={classNames('relative group/block', className, dataClassName, {
-        [subGrid]: !noSubGrid,
         hidden: node.visibility === 'remove',
       })}
     >

--- a/packages/myst-to-react/src/index.tsx
+++ b/packages/myst-to-react/src/index.tsx
@@ -23,7 +23,7 @@ import EXERCISE_RENDERERS from './exercise.js';
 import ASIDE_RENDERERS from './aside.js';
 import UNKNOWN_MYST_RENDERERS from './unknown.js';
 
-export { Block } from './block.js';
+export { Block, blockGridClassName } from './block.js';
 export { CopyIcon, HoverPopover, Tooltip, LinkCard } from './components/index.js';
 export { CodeBlock } from './code.js';
 export { HashLink, scrollToElement } from './hashLink.js';

--- a/themes/article/app/components/Article.tsx
+++ b/themes/article/app/components/Article.tsx
@@ -45,6 +45,7 @@ export function Article({
   hideTitle?: boolean;
   outlineMaxDepth?: number;
 }) {
+  const grid = useGridSystemProvider();
   const manifest = useProjectManifest();
   const keywords = article.frontmatter?.keywords ?? [];
   const tree = copyNode(article.mdast);

--- a/themes/article/app/components/Article.tsx
+++ b/themes/article/app/components/Article.tsx
@@ -23,11 +23,12 @@ import {
   useThemeTop,
   useMediaQuery,
   useProjectManifest,
+  useGridSystemProvider,
 } from '@myst-theme/providers';
 import type { GenericParent } from 'myst-common';
 import { copyNode } from 'myst-common';
 import { SourceFileKind } from 'myst-spec-ext';
-import { MyST } from 'myst-to-react';
+import { MyST, blockGridClassName } from 'myst-to-react';
 
 const TOP_OFFSET = 24;
 
@@ -93,7 +94,9 @@ export function Article({
           <ErrorTray pageSlug={article.slug} />
           <div id="skip-to-article" />
           <FrontmatterParts parts={parts} keywords={keywords} hideKeywords={hideKeywords} />
-          <MyST ast={tree.children as GenericParent[]} />
+          {...(tree.children as GenericParent[]).map((block) => (
+            <MyST ast={block} className={blockGridClassName(block, grid)} />
+          ))}
           <BackmatterParts parts={parts} />
           <Footnotes />
           <Bibliography />

--- a/themes/book/app/components/ArticlePage.tsx
+++ b/themes/book/app/components/ArticlePage.tsx
@@ -5,6 +5,7 @@ import {
   useSiteManifest,
   useThemeTop,
   useMediaQuery,
+  useGridSystemProvider,
 } from '@myst-theme/providers';
 import {
   Bibliography,
@@ -27,7 +28,7 @@ import {
   ErrorTray,
   useComputeOptions,
 } from '@myst-theme/jupyter';
-import { MyST } from 'myst-to-react';
+import { MyST, blockGridClassName } from 'myst-to-react';
 import { FrontmatterBlock } from '@myst-theme/frontmatter';
 import type { SiteAction } from 'myst-config';
 import type { TemplateOptions } from '../types.js';
@@ -78,6 +79,7 @@ export const ArticlePage = React.memo(function ({
   const isOutlineMargin = useMediaQuery('(min-width: 1024px)');
   const { thebe } = manifest as any;
   const { location } = article;
+  const grid = useGridSystemProvider();
 
   return (
     <ArticleProvider
@@ -116,7 +118,9 @@ export const ArticlePage = React.memo(function ({
           )}
           <div id="skip-to-article" />
           <FrontmatterParts parts={parts} keywords={keywords} hideKeywords={hideKeywords} />
-          <MyST ast={tree.children as GenericParent[]} />
+          {...(tree.children as GenericParent[]).map((block) => (
+            <MyST ast={block} className={blockGridClassName(block, grid)} />
+          ))}
           <BackmatterParts parts={parts} />
           <Footnotes />
           <Bibliography />


### PR DESCRIPTION
One solution to jupyter-book/mystmd#1886 is to pull the top-level display logic _out_ of the `Block` component and into the caller. 