### PR TITLE
🧹 Clean up links to EB & unify READMEs for packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `myst-theme`
 
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/executablebooks/myst-theme/blob/main/LICENSE)
-[![CI](https://github.com/executablebooks/myst-theme/workflows/CI/badge.svg)](https://github.com/executablebooks/myst-theme/actions)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/jupyter-book/myst-theme/blob/main/LICENSE)
+[![CI](https://github.com/jupyter-book/myst-theme/workflows/CI/badge.svg)](https://github.com/jupyter-book/myst-theme/actions)
 
 Packages for creating MyST websites themes using React and Remix.
 
@@ -55,7 +55,7 @@ When first cloning the repository use `git clone --recursive`,
 then install the various dependencies:
 
 ```
-git clone --recursive https://github.com/executablebooks/myst-theme.git
+git clone --recursive https://github.com/jupyter-book/myst-theme.git
 cd myst-theme
 npm install
 ```

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,9 +7,9 @@
   "author": "Rowan Cockett <rowan@curvenote.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/executablebooks/myst-theme/issues"
+    "url": "https://github.com/jupyter-book/myst-theme/issues"
   },
-  "homepage": "https://github.com/executablebooks/myst-theme",
+  "homepage": "https://github.com/jupyter-book/myst-theme",
   "devDependencies": {
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-react": "^7.22.5",

--- a/docs/stories/0-Introduction.stories.mdx
+++ b/docs/stories/0-Introduction.stories.mdx
@@ -11,7 +11,7 @@ import { MyST, Admonition, DEFAULT_RENDERERS } from 'myst-to-react';
       subject: '@myst-theme',
       venue: { title: 'Executable Books' },
       title: 'Welcome to MyST Theme',
-      github: 'https://github.com/executablebooks/myst-theme',
+      github: 'https://github.com/jupyter-book/myst-theme',
     }}
   />
 </div>

--- a/docs/stories/2-Admonitions.stories.mdx
+++ b/docs/stories/2-Admonitions.stories.mdx
@@ -16,7 +16,7 @@ export const Template = (args) => (
       subject: '@myst-theme',
       venue: { title: 'Executable Books' },
       title: 'Admonitions',
-      github: 'https://github.com/executablebooks/myst-theme',
+      github: 'https://github.com/jupyter-book/myst-theme',
     }}
   />
 </div>

--- a/docs/stories/2-Dropdown.stories.mdx
+++ b/docs/stories/2-Dropdown.stories.mdx
@@ -16,7 +16,7 @@ export const Template = (args) => (
       subject: '@myst-theme',
       venue: { title: 'Executable Books' },
       title: 'Dropdowns',
-      github: 'https://github.com/executablebooks/myst-theme',
+      github: 'https://github.com/jupyter-book/myst-theme',
     }}
   />
 </div>

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,3 +1,6 @@
 # @myst-theme/common
 
+[![@myst-theme/common on npm](https://img.shields.io/npm/v/@myst-theme/common.svg)](https://www.npmjs.com/package/@myst-theme/common)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/jupyter-book/myst-theme/blob/main/LICENSE)
+
 Common utilities and types for working with the MyST Theme and sites

--- a/packages/diagrams/README.md
+++ b/packages/diagrams/README.md
@@ -1,6 +1,6 @@
 # @myst-theme/diagrams
 
-[![myst-demo on npm](https://img.shields.io/npm/v/myst-demo.svg)](https://www.npmjs.com/package/myst-demo)
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/curvenote/curvenote/blob/main/LICENSE)
+[![@myst-theme/diagrams on npm](https://img.shields.io/npm/v/myst-demo.svg)](https://www.npmjs.com/package/@myst-theme/diagrams)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/jupyter-book/myst-theme/blob/main/LICENSE)
 
-A demo component for MyST
+React components for diagram renderers used by MyST.

--- a/packages/frontmatter/README.md
+++ b/packages/frontmatter/README.md
@@ -1,6 +1,6 @@
 # @myst-theme/frontmatter
 
 [![@myst-theme/frontmatter on npm](https://img.shields.io/npm/v/@myst-theme/frontmatter.svg)](https://www.npmjs.com/package/@myst-theme/frontmatter)
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/curvenote/curvenote/blob/main/LICENSE)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/jupyter-book/myst-theme/blob/main/LICENSE)
 
-Convert a MyST AST to React.
+React components for rendering MyST frontmatter.

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,5 +1,8 @@
 # @myst-theme/icons
 
+[![@myst-theme/icons on npm](https://img.shields.io/npm/v/@myst-theme/icons.svg)](https://www.npmjs.com/package/@myst-theme/icons)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/jupyter-book/myst-theme/blob/main/LICENSE)
+
 MyST icons for React applications:
 
 ```typescript

--- a/packages/jupyter/CHANGELOG.md
+++ b/packages/jupyter/CHANGELOG.md
@@ -272,7 +272,7 @@
 
 ### Patch Changes
 
-- 947ddf37: Fix for [322](https://github.com/executablebooks/myst-theme/issues/322) waiting for plotly during notebook build
+- 947ddf37: Fix for [322](https://github.com/jupyter-book/myst-theme/issues/322) waiting for plotly during notebook build
   - @myst-theme/providers@0.6.1
   - myst-to-react@0.6.1
 
@@ -765,7 +765,7 @@
 
 ### Patch Changes
 
-- f03ceba: Fixes logic that identified outputs as all safe when unsafe outputs were mixed with safe in the same output array. [issue 34](https://github.com/executablebooks/myst-theme/issues/34)
+- f03ceba: Fixes logic that identified outputs as all safe when unsafe outputs were mixed with safe in the same output array. [issue 34](https://github.com/jupyter-book/myst-theme/issues/34)
 - e35e10e: Update packages (especially headlessui)
   - @myst-theme/providers@0.1.30
 

--- a/packages/jupyter/README.md
+++ b/packages/jupyter/README.md
@@ -1,6 +1,6 @@
-# @myst-theme/diagrams
+# @myst-theme/jupyter
 
-[![myst-demo on npm](https://img.shields.io/npm/v/myst-demo.svg)](https://www.npmjs.com/package/myst-demo)
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/curvenote/curvenote/blob/main/LICENSE)
+[![@myst-theme/jupyter on npm](https://img.shields.io/npm/v/@myst-theme/jupyter.svg)](https://www.npmjs.com/package/@myst-theme/jupyter)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/jupyter-book/myst-theme/blob/main/LICENSE)
 
-A demo component for MyST
+React components for integrating Jupyter with MyST.

--- a/packages/myst-demo/README.md
+++ b/packages/myst-demo/README.md
@@ -1,7 +1,7 @@
 # myst-demo
 
 [![myst-demo on npm](https://img.shields.io/npm/v/myst-demo.svg)](https://www.npmjs.com/package/myst-demo)
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/curvenote/curvenote/blob/main/LICENSE)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/jupyter-book/myst-theme/blob/main/LICENSE)
 
 A demo component for MyST Markdown, for example, [in the sandbox](https://mystmd.org/sandbox).
 

--- a/packages/myst-to-react/README.md
+++ b/packages/myst-to-react/README.md
@@ -1,6 +1,6 @@
 # myst-to-react
 
 [![myst-to-react on npm](https://img.shields.io/npm/v/myst-to-react.svg)](https://www.npmjs.com/package/myst-to-react)
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/curvenote/curvenote/blob/main/LICENSE)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/jupyter-book/myst-theme/blob/main/LICENSE)
 
 Convert a MyST AST to React.

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -1,0 +1,6 @@
+# @myst-theme/providers
+
+[![@myst-theme/providers on npm](https://img.shields.io/npm/v/@myst-theme/providers.svg)](https://www.npmjs.com/package/@myst-theme/providers)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/jupyter-book/myst-theme/blob/main/LICENSE)
+
+React Context providers for MyST sites.

--- a/packages/search-minisearch/README.md
+++ b/packages/search-minisearch/README.md
@@ -1,3 +1,6 @@
 # @myst-theme/search-minisearch
 
+[![@myst-theme/search-minisearch on npm](https://img.shields.io/npm/v/@myst-theme/search-minisearch.svg)](https://www.npmjs.com/package/@myst-theme/search-minisearch)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/jupyter-book/myst-theme/blob/main/LICENSE)
+
 A minisearch implementation for client-side searching in MyST sites.

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -1,3 +1,6 @@
 # @myst-theme/search
 
+[![@myst-theme/search on npm](https://img.shields.io/npm/v/@myst-theme/search.svg)](https://www.npmjs.com/package/@myst-theme/search)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/jupyter-book/myst-theme/blob/main/LICENSE)
+
 An implementation and spec for client-side searching in MyST sites.

--- a/packages/site/README.md
+++ b/packages/site/README.md
@@ -1,0 +1,6 @@
+# @myst-theme/site
+
+[![@myst-theme/site on npm](https://img.shields.io/npm/v/@myst-theme/site.svg)](https://www.npmjs.com/package/@myst-theme/site)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/jupyter-book/myst-theme/blob/main/LICENSE)
+
+TypeScript components for building MyST sites with React.

--- a/styles/CHANGELOG.md
+++ b/styles/CHANGELOG.md
@@ -48,7 +48,7 @@
 
 ### Patch Changes
 
-- 929f161b: Revert recent `col-margin` change to fix [442](https://github.com/executablebooks/myst-theme/issues/422)
+- 929f161b: Revert recent `col-margin` change to fix [442](https://github.com/jupyter-book/myst-theme/issues/422)
 
 ## 0.9.8
 

--- a/styles/package.json
+++ b/styles/package.json
@@ -10,9 +10,9 @@
   "author": "Rowan Cockett <rowan@curvenote.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/executablebooks/myst-theme/issues"
+    "url": "https://github.com/jupyter-book/myst-theme/issues"
   },
-  "homepage": "https://github.com/executablebooks/myst-theme",
+  "homepage": "https://github.com/jupyter-book/myst-theme",
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.9",
     "tailwindcss": "^3.2.4"

--- a/themes/article/.gitmodules
+++ b/themes/article/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "patches"]
 	path = patches
-	url = https://github.com/executablebooks/myst-theme-patches
+	url = https://github.com/jupyter-book/myst-theme-patches

--- a/themes/article/README.md
+++ b/themes/article/README.md
@@ -21,7 +21,7 @@ Open up [http://localhost:3000](http://localhost:3000) and you should be ready t
 
 ## Development
 
-This repository depends on the packages in [myst-theme](https://github.com/executablebooks/myst-theme) and is best developed in that repository to allow for live-reload, etc.
+This repository depends on the packages in [myst-theme](https://github.com/jupyter-book/myst-theme) and is best developed in that repository to allow for live-reload, etc.
 
 ## Deployment
 

--- a/themes/article/template.yml
+++ b/themes/article/template.yml
@@ -3,7 +3,7 @@ title: Article Theme
 description: Simple site for displaying an article with associated notebooks.
 version: 1.0.0
 license: MIT
-source: https://github.com/executablebooks/myst-theme
+source: https://github.com/jupyter-book/myst-theme
 thumbnail: ./thumbnail.png
 authors:
   - name: Rowan Cockett

--- a/themes/book/README.md
+++ b/themes/book/README.md
@@ -21,7 +21,7 @@ Open up [http://localhost:3000](http://localhost:3000) and you should be ready t
 
 ## Development
 
-This repository depends on the packages in [myst-theme](https://github.com/executablebooks/myst-theme) and is best developed in that repository to allow for live-reload, etc.
+This repository depends on the packages in [myst-theme](https://github.com/jupyter-book/myst-theme) and is best developed in that repository to allow for live-reload, etc.
 
 ## Deployment
 


### PR DESCRIPTION
This PR does some general cleanup to remove EB references where we now use JB, and to ensure that the links and badges are all up to date.