### PR TITLE
🌲 Add `root` renderer

### DIFF
--- a/.changeset/large-needles-end.md
+++ b/.changeset/large-needles-end.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Add `root` renderer

--- a/.changeset/rotten-mangos-rescue.md
+++ b/.changeset/rotten-mangos-rescue.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Ensure that a node with `{length: 0}` as a property can be rendered.

--- a/packages/myst-demo/src/index.tsx
+++ b/packages/myst-demo/src/index.tsx
@@ -408,7 +408,7 @@ export function MySTRenderer({
       )}
     >
       {column && (
-        <div className="flex flex-row col-span-2 items-stretch px-2 h-full border dark:border-slate-600">
+        <div className="flex flex-row items-stretch h-full col-span-2 px-2 border dark:border-slate-600">
           <div className="flex-grow"></div>
           {demoMenu}
         </div>
@@ -452,7 +452,7 @@ export function MySTRenderer({
               >
                 <GridSystemProvider gridSystem="demo-grid">
                   {TitleBlock && <TitleBlock frontmatter={frontmatter}></TitleBlock>}
-                  <MyST ast={references.article?.children as GenericNode[]} />
+                  <MyST ast={references.article} />
                 </GridSystemProvider>
               </ArticleProvider>
             </>
@@ -474,7 +474,7 @@ export function MySTRenderer({
           {previewType === 'DOCX' && (
             <div>
               <button
-                className="p-3 rounded border"
+                className="p-3 border rounded"
                 onClick={() => saveDocxFile('demo.docx', references.article)}
                 title={`Download Micorsoft Word`}
                 aria-label={`Download Micorsoft Word`}

--- a/packages/myst-to-react/src/MyST.tsx
+++ b/packages/myst-to-react/src/MyST.tsx
@@ -28,11 +28,12 @@ export function MyST({
   className?: string;
 }) {
   const renderers = useNodeRenderers();
-  if (!ast || ast.length === 0) return null;
+  if (!ast) return null;
   if (!Array.isArray(ast)) {
     const Component = selectRenderer(renderers, ast);
     return <Component key={ast.key} node={ast} className={className} />;
   }
+  if (ast.length === 0) return null;
   return (
     <>
       {ast?.map((node) => {

--- a/packages/myst-to-react/src/basic.tsx
+++ b/packages/myst-to-react/src/basic.tsx
@@ -54,6 +54,10 @@ type Glossary = {
   type: 'glossary';
 };
 
+type Root = {
+  type: 'root';
+};
+
 type BasicNodeRenderers = {
   text: NodeRenderer<spec.Text>;
   span: NodeRenderer<GenericNode>;
@@ -95,6 +99,7 @@ type BasicNodeRenderers = {
   definitionDescription: NodeRenderer<DefinitionDescription>;
   include: NodeRenderer<Include>;
   glossary: NodeRenderer<Glossary>;
+  root: NodeRenderer<Root>;
 };
 
 const BASIC_RENDERERS: BasicNodeRenderers = {
@@ -411,6 +416,15 @@ const BASIC_RENDERERS: BasicNodeRenderers = {
         <MyST ast={node.children} />
       </div>
     );
+  },
+  root({ node, className }) {
+    if (node.children === undefined) {
+      return <></>;
+    }
+    const childComponents = node.children.map((child) => (
+      <MyST ast={child} className={className} />
+    ));
+    return <>{...childComponents}</>;
   },
 };
 

--- a/packages/myst-to-react/src/basic.tsx
+++ b/packages/myst-to-react/src/basic.tsx
@@ -418,13 +418,7 @@ const BASIC_RENDERERS: BasicNodeRenderers = {
     );
   },
   root({ node, className }) {
-    if (node.children === undefined) {
-      return <></>;
-    }
-    const childComponents = node.children.map((child) => (
-      <MyST ast={child} className={className} />
-    ));
-    return <>{...childComponents}</>;
+    return <MyST ast={node.children} className={className} />;
   },
 };
 

--- a/themes/article/app/components/Article.tsx
+++ b/themes/article/app/components/Article.tsx
@@ -93,7 +93,7 @@ export function Article({
           <ErrorTray pageSlug={article.slug} />
           <div id="skip-to-article" />
           <FrontmatterParts parts={parts} keywords={keywords} hideKeywords={hideKeywords} />
-          <MyST ast={tree.children as GenericParent[]} />
+          <MyST ast={tree} />
           <BackmatterParts parts={parts} />
           <Footnotes />
           <Bibliography />

--- a/themes/book/app/components/ArticlePage.tsx
+++ b/themes/book/app/components/ArticlePage.tsx
@@ -116,7 +116,7 @@ export const ArticlePage = React.memo(function ({
           )}
           <div id="skip-to-article" />
           <FrontmatterParts parts={parts} keywords={keywords} hideKeywords={hideKeywords} />
-          <MyST ast={tree.children as GenericParent[]} />
+          <MyST ast={tree} />
           <BackmatterParts parts={parts} />
           <Footnotes />
           <Bibliography />


### PR DESCRIPTION
By imposing the constraint that `root` cannot have a `class` or `label`, we can eliminate the need to render a `div` for this element.