### PR TITLE
🖥️ Add deploy workflow to CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
+      - name: Install dependencies
+        # TODO: this only needs to install thebe install deps
+        run: npm install
       - name: Configure Git
         run: git config --global url."https://${{ secrets.MYST_TEMPLATES_USER }}:${{ secrets.MYST_TEMPLATES_TOKEN}}@github.com".insteadOf "https://github.com"
       - name: Deploy book

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,9 +21,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-      - name: Install dependencies
+      - name: Install Dependencies
         # TODO: this only needs to install thebe install deps
         run: npm install
+      - name: Build MyST Theme
+        run: npm run build
       - name: Configure Git
         run: git config --global url."https://${{ secrets.MYST_TEMPLATES_USER }}:${{ secrets.MYST_TEMPLATES_TOKEN}}@github.com".insteadOf "https://github.com"
       - name: Deploy book

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+
+name: Release
+on:
+  release
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release:
+    strategy:
+      matrix:
+        theme: [book, article]
+    name: Release ${{ matrix.theme }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - name: Configure Git
+        run: git config --global url."https://${{ secrets.MYST_TEMPLATES_USER }}:${{ secrets.MYST_TEMPLATES_TOKEN}}@github.com".insteadOf "https://github.com"
+      - name: Deploy book
+        run: make deploy-${{ matrix.theme }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Build MyST Theme
         run: npm run build
       - name: Configure Git
-        run: git config --global url."https://${{ secrets.MYST_TEMPLATES_USER }}:${{ secrets.MYST_TEMPLATES_TOKEN}}@github.com".insteadOf "https://github.com"
+        run: |
+          git config --global url."https://${{ secrets.MYST_TEMPLATES_USER }}:${{ secrets.MYST_TEMPLATES_TOKEN}}@github.com".insteadOf "https://github.com"
+          git config --global user.email "bot@github.com"
+          git config --global user.name "MyST Theme Bot"
       - name: Deploy book
         run: make deploy-${{ matrix.theme }}


### PR DESCRIPTION
This PR adds a deployment workflow that uses a personal fine-grained GitHub token to push to `myst-templates`. It will expire in 365 days. I've already tested this with https://github.com/myst-templates/book-theme/commit/c4a0e5d80187e543ef3363ae725b2007aa9b3683