### PR TITLE
🎓 Add support for `button` in `cite` nodes

### DIFF
--- a/packages/myst-to-react/src/cite.tsx
+++ b/packages/myst-to-react/src/cite.tsx
@@ -67,11 +67,17 @@ export const Cite = ({
     return <InlineError value={label} message={'Citation Not Found'} className={className} />;
   }
   const url = doiString ? doi.buildUrl(doiString as string) : refUrl;
+  const isButtonLike = (className ?? '').split(' ').includes('button');
   return (
     <HoverPopover openDelay={300} card={<CiteChild html={html} />}>
       <cite className={className}>
         {url && (
-          <a href={url} target="_blank" rel="noreferrer" className="hover-link">
+          <a
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            className={classNames({ 'hover-link': !isButtonLike })}
+          >
             {children}
           </a>
         )}
@@ -84,7 +90,7 @@ export const Cite = ({
 export const CiteRenderer: NodeRenderer = ({ node, className }) => {
   const numbered = useNumberedReferences();
   return (
-    <Cite label={node.label} error={node.error} className={className}>
+    <Cite label={node.label} error={node.error} className={classNames(className, node.class)}>
       {numbered && node.kind === 'parenthetical' ? node.enumerator : <MyST ast={node.children} />}
     </Cite>
   );

--- a/styles/button.css
+++ b/styles/button.css
@@ -1,9 +1,8 @@
-a.button {
+a.button,
+cite.button a {
   @apply px-4 py-2 font-bold rounded no-underline;
-}
-a.button {
   @apply text-white bg-blue-500 whitespace-nowrap;
-}
-a.button:hover {
-  @apply bg-blue-700;
+  &:hover {
+    @apply bg-blue-700;
+  }
 }


### PR DESCRIPTION
This PR follows up #521 to support buttons with citations. In the long run, I think we might want to replace these selectors with something more React driven, but this is a first pass.