### PR TITLE
⬆️ Bump Node.js version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - run: npm install
       - run: npm run build
       - run: npm run test


### PR DESCRIPTION
In debugging a difference between the deployed and locally built themes, I noticed that we're only using Node.js 16. We purport to require >16 for MyST-MD, and we should really bump this to a newer version.