### PR TITLE
➿ Enable flex-wrap in landing-page links

### DIFF
--- a/.changeset/swift-beds-raise.md
+++ b/.changeset/swift-beds-raise.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/landing-pages': patch
+---
+
+Fix wrapping of links on landing pages

--- a/packages/landing-pages/src/CenteredBlock.tsx
+++ b/packages/landing-pages/src/CenteredBlock.tsx
@@ -58,7 +58,7 @@ export function CenteredBlock(props: Omit<LandingBlockProps, 'children'>) {
             </div>
           )}
           {links && (
-            <div className="flex items-center justify-center gap-4 mt-8">
+            <div className="flex flex-row flex-wrap items-center justify-center gap-4 mt-8">
               <MyST ast={links} />
             </div>
           )}

--- a/packages/landing-pages/src/JustifiedBlock.tsx
+++ b/packages/landing-pages/src/JustifiedBlock.tsx
@@ -62,7 +62,7 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
           </div>
           <div className="flex flex-col mt-8 lg:mt-0">
             {links && (
-              <div className="flex flex-row items-center gap-4">
+              <div className="flex flex-row flex-wrap items-center gap-4">
                 <MyST ast={links} />
               </div>
             )}

--- a/packages/landing-pages/src/LogoCloudBlock.tsx
+++ b/packages/landing-pages/src/LogoCloudBlock.tsx
@@ -42,7 +42,7 @@ export function LogoCloudBlock(props: Omit<LandingBlockProps, 'children'>) {
         </div>
         {grid && <MyST ast={grid} />}
         {links && (
-          <div className="flex items-center justify-center gap-4 mt-8">
+          <div className="flex flex-row flex-wrap items-center justify-center gap-4 mt-8">
             <MyST ast={links} />
           </div>
         )}

--- a/packages/landing-pages/src/SplitImageBlock.tsx
+++ b/packages/landing-pages/src/SplitImageBlock.tsx
@@ -63,7 +63,7 @@ export function SplitImageBlock(props: Omit<LandingBlockProps, 'children'>) {
               <MyST ast={body} className="prose prose-invert" />
             </div>
             {links && (
-              <div className="flex items-center gap-4 mt-8">
+              <div className="flex flex-row flex-wrap items-center gap-4 mt-8">
                 <MyST ast={links} className="prose prose-invert" />
               </div>
             )}


### PR DESCRIPTION
**Before**

![image](https://github.com/user-attachments/assets/4a1b6abb-da61-49e7-b35e-64968b9c4828)


**After**

![image](https://github.com/user-attachments/assets/0d8a6f94-03e9-4986-a9d8-9b8ec4dc2d6b)
