### PR TITLE
🖼️ Fix layout of `justified` landing blocks

### DIFF
--- a/.changeset/quick-needles-judge.md
+++ b/.changeset/quick-needles-judge.md
@@ -1,0 +1,6 @@
+---
+'@myst-theme/landing-pages': patch
+'@myst-theme/styles': patch
+---
+
+Fix justified landing-page block layout

--- a/packages/landing-pages/src/JustifiedBlock.tsx
+++ b/packages/landing-pages/src/JustifiedBlock.tsx
@@ -40,34 +40,28 @@ export function JustifiedBlock(props: Omit<LandingBlockProps, 'children'>) {
   }
   return (
     <LandingBlock {...props}>
-      <div className="py-20 sm:py-28 lg:px-8">
+      <div className="grid-areas-just-narrow md:grid-areas-just-wide grid grid-cols-[auto_1fr_auto] justify-between gap-2 py-20 sm:py-28 lg:px-8">
         {subtitle && (
-          <p className="my-0 font-semibold text-indigo-400 uppercase">
+          <p className="grid-area-subtitle my-0 font-semibold text-indigo-400 uppercase">
             <MyST ast={subtitle.children} />
           </p>
         )}
-        <div className="flex flex-col lg:content-center lg:justify-between lg:flex-row">
-          <div className="flex flex-col">
-            {heading && (
-              <BlockHeading
-                node={heading}
-                className="mt-2 mb-0 text-5xl font-semibold tracking-tight"
-              />
-            )}
-            {body && (
-              <div className="mt-6">
-                <MyST ast={body} />
-              </div>
-            )}
+        {heading && (
+          <BlockHeading
+            node={heading}
+            className="grid-area-title mt-2 mb-0 text-5xl font-semibold tracking-tight"
+          />
+        )}
+        {body && (
+          <div className="grid-area-body mt-6">
+            <MyST ast={body} />
           </div>
-          <div className="flex flex-col mt-8 lg:mt-0">
-            {links && (
-              <div className="flex flex-row flex-wrap items-center gap-4">
-                <MyST ast={links} />
-              </div>
-            )}
+        )}
+        {links && (
+          <div className="grid-area-links flex flex-row flex-wrap items-center gap-4">
+            <MyST ast={links} />
           </div>
-        </div>
+        )}
       </div>
     </LandingBlock>
   );

--- a/styles/app.css
+++ b/styles/app.css
@@ -10,6 +10,7 @@
 @import './math.css';
 @import './cross-references.css';
 @import './block-styles.css';
+@import './landing-pages.css';
 @import './jupyter.css';
 @import './tasklists.css';
 @import './sphinx.css';

--- a/styles/landing-pages.css
+++ b/styles/landing-pages.css
@@ -1,0 +1,28 @@
+/* CSS rules for grid configuration of landing pages */
+@layer components {
+  .grid-area-subtitle {
+    grid-area: subtitle;
+  }
+  .grid-area-title {
+    grid-area: title;
+  }
+  .grid-area-body {
+    grid-area: body;
+  }
+  .grid-area-links {
+    grid-area: links;
+  }
+  .grid-areas-just-narrow {
+    grid-template-areas:
+      'subtitle subtitle subtitle'
+      'title title title'
+      'body body body'
+      'links links links';
+  }
+  .grid-areas-just-wide {
+    grid-template-areas:
+      'subtitle subtitle subtitle'
+      'title . links'
+      'body body body';
+  }
+}


### PR DESCRIPTION
Fixes #575 by switching to a CSS grid layout, rather than a set of flex boxes. This ensures that we can responsively move links _below_ the main body of the section, and prevent links from stealing _body_ width.

![Screenshot 2025-04-15 at 15-00-08 Project Pythia](https://github.com/user-attachments/assets/abf95013-5128-4596-8e28-ec5b583ba1ac)
