### PR TITLE
✍️ Feat: add edit button

### DIFF
--- a/.changeset/rich-suits-sniff.md
+++ b/.changeset/rich-suits-sniff.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/frontmatter': minor
+---
+
+add edit button

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -8,6 +8,8 @@ import { DownloadsDropdown } from './downloads.js';
 import { AuthorAndAffiliations, AuthorsList } from './Authors.js';
 import { LaunchButton } from './LaunchButton.js';
 
+import { PencilSquareIcon } from '@heroicons/react/24/outline';
+
 function ExternalOrInternalLink({
   to,
   className,
@@ -151,6 +153,24 @@ export function OpenAccessBadge({ open_access }: { open_access?: boolean }) {
   );
 }
 
+export function EditLink({ editUrl }: { editUrl?: string }) {
+  return (
+    <a
+      href={editUrl}
+      title={`Edit This Page`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-inherit hover:text-inherit"
+    >
+      <PencilSquareIcon
+        width="1.25rem"
+        height="1.25rem"
+        className="inline-block mr-1 opacity-60 hover:opacity-100"
+      />
+    </a>
+  );
+}
+
 export function Journal({
   venue,
   volume,
@@ -224,6 +244,7 @@ export function FrontmatterBlock({
     date,
     authors,
     enumerator,
+    edit_url,
   } = frontmatter;
   const isJupyter = kind === SourceFileKind.Notebook;
   const hasExports = downloads ? downloads.length > 0 : exports && exports.length > 0;
@@ -274,6 +295,7 @@ export function FrontmatterBlock({
               )}
             </>
           )}
+          {edit_url && <EditLink editUrl={edit_url} />}
           {!hideExports && <DownloadsDropdown exports={(downloads ?? exports) as any} />}
           {!hideLaunch && thebe && location && <LaunchButton thebe={thebe} location={location} />}
         </div>

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -157,7 +157,7 @@ export function EditLink({ editUrl }: { editUrl?: string }) {
   return (
     <a
       href={editUrl}
-      title={`Edit This Page`}
+      title="Edit This Page"
       target="_blank"
       rel="noopener noreferrer"
       className="text-inherit hover:text-inherit"

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -154,6 +154,7 @@ export function OpenAccessBadge({ open_access }: { open_access?: boolean }) {
 }
 
 export function EditLink({ editUrl }: { editUrl?: string }) {
+  if (!editUrl) return null;
   return (
     <a
       href={editUrl}
@@ -295,7 +296,7 @@ export function FrontmatterBlock({
               )}
             </>
           )}
-          {edit_url && <EditLink editUrl={edit_url} />}
+          <EditLink editUrl={edit_url ?? undefined} />
           {!hideExports && <DownloadsDropdown exports={(downloads ?? exports) as any} />}
           {!hideLaunch && thebe && location && <LaunchButton thebe={thebe} location={location} />}
         </div>


### PR DESCRIPTION
Adds an edit button to pages that have GitHub repo information to edit the corresponding page on the site.

![Screenshot 2025-05-12 at 4 17 08 PM](https://github.com/user-attachments/assets/ca19d42d-c2f8-44e8-b35e-38bf0e2d8e3c)

closes #326 