### PR TITLE
🗽 Liberate the footer from the article-grid

### DIFF
--- a/themes/book/app/components/Footer.tsx
+++ b/themes/book/app/components/Footer.tsx
@@ -7,7 +7,7 @@ export function Footer({ content, className }: { content: GenericParent; classNa
     // Outer footer, sets up the grid, leaves margin above
     <footer
       className={classNames(
-        'article footer article-grid bg-white dark:bg-slate-950 mt-10 shadow-2xl shadow py-10',
+        'article footer bg-white dark:bg-slate-950 mt-10 shadow-2xl shadow py-10',
         className,
       )}
     >


### PR DESCRIPTION
It's mighty tight if you *have* to fit the footer inside the article-grid!

I think this is also more along the line of what we discussed: that the footer should have a large amount of flexibility in how it is laid out.