### PR TITLE
🤏 Fix grid-system footer override syntax error

### DIFF
--- a/themes/book/styles/grid-system.css
+++ b/themes/book/styles/grid-system.css
@@ -1,13 +1,13 @@
 @layer base {
-  /* 
-* The default article-grid styles affect body content via `.article-grid > *` 
-* We want to style body-content of the footer, which is footer .article-grid > *
-* Users will add col- classes to their markup to override this.
-* We use :where() to avoid taking higher specificity than user-defined rules (0-1-0)
-*/
+/*
+ * The default article-grid styles affect body content via `.article-grid > *`
+ * We want to style body-content of the footer, which is footer .article-grid > *
+ * Users will add col- classes to their markup to override this.
+ * We use :where() to avoid taking higher specificity than user-defined rules (0-1-0)
+ */
   :where(footer).article-grid > *,
   :where(footer).article-left-grid > *,
-  :where(footer).article-center-grid > *,
+  :where(footer).article-center-grid > *
   {
     @apply col-page;
   }


### PR DESCRIPTION
Remove a spurious comma that was left in the style file for book-theme.