### PR TITLE
📐 add padding to notebook block

### DIFF
--- a/.changeset/eight-spoons-melt.md
+++ b/.changeset/eight-spoons-melt.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/jupyter': patch
+---
+
+This fixes a hover issue where the notebook run cell and clear cell and bottle buttons were unreachable on hover.

--- a/packages/jupyter/src/block.tsx
+++ b/packages/jupyter/src/block.tsx
@@ -15,7 +15,7 @@ export function NotebookBlock({ node, className }: { node: GenericParent; classN
   const block = (
     <div
       id={node.key}
-      className={classNames('relative group/block', className, node.class, {
+      className={classNames('relative group/block pr-[28px]', className, node.class, {
         [node.data?.class]: typeof node.data?.class === 'string',
         hidden: node.visibility === 'remove',
       })}


### PR DESCRIPTION
A minimal fix for issue #593 by adding a minimal right padding to extend the hover area.
