### PR TITLE
Add flex-wrap to tabs

### DIFF
--- a/packages/myst-to-react/src/tabs.tsx
+++ b/packages/myst-to-react/src/tabs.tsx
@@ -52,7 +52,7 @@ export function TabSet({
   return (
     <TabSetStateProvider active={active}>
       <div className={classNames('my-5', className)}>
-        <div className="flex flex-row overflow-x-auto border-b border-b-gray-100">
+        <div className="flex flex-row flex-wrap overflow-x-auto border-b border-b-gray-100">
           {tabs.map((tab) => {
             return (
               <div


### PR DESCRIPTION
I suggest that this is necessary for really long tab sets so that all the tabs would fit by default. Right now, a scroll bar is created, which is less user-friendly, which seems to go against MyST values.