### PR TITLE
Make Jupyter tables readable in dark theme

### DIFF
--- a/.changeset/slimy-nights-fail.md
+++ b/.changeset/slimy-nights-fail.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/site': minor
+---
+
+Make Jupyter tables readable in dark theme

--- a/packages/jupyter/src/controls/NotebookCellControls.tsx
+++ b/packages/jupyter/src/controls/NotebookCellControls.tsx
@@ -5,7 +5,13 @@ export function NotebookRunCell({ id }: { id: string }) {
   const { ready, cellIsExecuting, notebookIsBusy, execute } = useCellExecution(id);
   if (!ready) return null;
   return (
-    <Run ready={ready} executing={cellIsExecuting} disabled={notebookIsBusy} onClick={execute} title="Run cell" />
+    <Run
+      ready={ready}
+      executing={cellIsExecuting}
+      disabled={notebookIsBusy}
+      onClick={execute}
+      title="Run cell"
+    />
   );
 }
 

--- a/packages/myst-to-react/src/admonitions.tsx
+++ b/packages/myst-to-react/src/admonitions.tsx
@@ -175,16 +175,16 @@ export function Admonition({
       dropdown={dropdown}
       open={open}
       className={classNames(
-        'my-5 shadow-md dark:shadow-2xl dark:shadow-neutral-900',
+        '-admonition-wrapper my-5 shadow-md dark:shadow-2xl dark:shadow-neutral-900',
         'bg-gray-50/10 dark:bg-stone-800',
         'overflow-hidden',
         {
-          'rounded border-l-4': !simple,
-          'border-l-2': simple,
-          'border-blue-500': !color || color === 'blue',
-          'border-green-600': color === 'green',
-          'border-amber-600': color === 'yellow',
-          'border-red-600': color === 'red',
+          '-admonition-wrapper-default rounded border-l-4': !simple,
+          '-admonition-wrapper-simple border-l-2': simple,
+          '-admonition-wrapper-blue border-blue-500': !color || color === 'blue',
+          '-admonition-wrapper-green border-green-600': color === 'green',
+          '-admonition-wrapper-yellow border-amber-600': color === 'yellow',
+          '-admonition-wrapper-red border-red-600': color === 'red',
         },
         className,
       )}
@@ -192,15 +192,15 @@ export function Admonition({
       {title && (
         <HeaderElement
           dropdown={dropdown}
-          className={classNames('m-0 font-medium py-1 flex min-w-0', {
-            'text-lg': !simple,
-            'text-md': simple,
+          className={classNames('-admonition-header m-0 font-medium py-1 flex min-w-0', {
+            '-admonition-header-default text-lg': !simple,
+            '-admonition-header-simple text-md': simple,
             'bg-gray-100 dark:bg-stone-700': simple,
-            'text-blue-600 bg-blue-50 dark:bg-slate-900': !simple && (!color || color === 'blue'),
-            'text-green-600 bg-green-50 dark:bg-slate-900': !simple && color === 'green',
-            'text-amber-600 bg-amber-50 dark:bg-slate-900': !simple && color === 'yellow',
-            'text-red-600 bg-red-50 dark:bg-slate-900': !simple && color === 'red',
-            'cursor-pointer hover:shadow-[inset_0_0_0px_30px_#00000003] dark:hover:shadow-[inset_0_0_0px_30px_#FFFFFF03]':
+            '-admonition-header-blue text-blue-600 bg-blue-50 dark:bg-slate-900': !simple && (!color || color === 'blue'),
+            '-admonition-header-green text-green-600 bg-green-50 dark:bg-slate-900': !simple && color === 'green',
+            '-admonition-header-yellow text-amber-600 bg-amber-50 dark:bg-slate-900': !simple && color === 'yellow',
+            '-admonition-header-red text-red-600 bg-red-50 dark:bg-slate-900': !simple && color === 'red',
+            '-admonition-header-dropdown cursor-pointer hover:shadow-[inset_0_0_0px_30px_#00000003] dark:hover:shadow-[inset_0_0_0px_30px_#FFFFFF03]':
               dropdown,
           })}
         >
@@ -209,6 +209,7 @@ export function Admonition({
               kind={kind ?? AdmonitionKind.note}
               className={classNames({
                 // Needed for simple!
+                // Not sure what exactly this defines, could be expanded
                 'text-blue-600': !color || color === 'blue',
                 'text-green-600': color === 'green',
                 'text-amber-600': color === 'yellow',
@@ -218,7 +219,7 @@ export function Admonition({
           )}
           <div
             className={classNames(
-              'text-neutral-900 dark:text-white grow self-center overflow-hidden break-words',
+              '-admonition-header-text text-neutral-900 dark:text-white grow self-center overflow-hidden break-words',
               { 'ml-4': hideIcon },
             )}
           >
@@ -235,7 +236,7 @@ export function Admonition({
           )}
         </HeaderElement>
       )}
-      <div className={classNames('px-4', { 'py-1': !simple, 'details-body': dropdown })}>
+      <div className={classNames('-admonition-paragraph-text px-4', { 'py-1': !simple, 'details-body': dropdown })}>
         {children}
       </div>
     </WrapperElement>

--- a/packages/myst-to-react/src/admonitions.tsx
+++ b/packages/myst-to-react/src/admonitions.tsx
@@ -175,16 +175,16 @@ export function Admonition({
       dropdown={dropdown}
       open={open}
       className={classNames(
-        '-admonition-wrapper my-5 shadow-md dark:shadow-2xl dark:shadow-neutral-900',
+        'my-5 shadow-md dark:shadow-2xl dark:shadow-neutral-900',
         'bg-gray-50/10 dark:bg-stone-800',
         'overflow-hidden',
         {
-          '-admonition-wrapper-default rounded border-l-4': !simple,
-          '-admonition-wrapper-simple border-l-2': simple,
-          '-admonition-wrapper-blue border-blue-500': !color || color === 'blue',
-          '-admonition-wrapper-green border-green-600': color === 'green',
-          '-admonition-wrapper-yellow border-amber-600': color === 'yellow',
-          '-admonition-wrapper-red border-red-600': color === 'red',
+          'rounded border-l-4': !simple,
+          'border-l-2': simple,
+          'border-blue-500': !color || color === 'blue',
+          'border-green-600': color === 'green',
+          'border-amber-600': color === 'yellow',
+          'border-red-600': color === 'red',
         },
         className,
       )}
@@ -192,15 +192,15 @@ export function Admonition({
       {title && (
         <HeaderElement
           dropdown={dropdown}
-          className={classNames('-admonition-header m-0 font-medium py-1 flex min-w-0', {
-            '-admonition-header-default text-lg': !simple,
-            '-admonition-header-simple text-md': simple,
+          className={classNames('m-0 font-medium py-1 flex min-w-0', {
+            'text-lg': !simple,
+            'text-md': simple,
             'bg-gray-100 dark:bg-stone-700': simple,
-            '-admonition-header-blue text-blue-600 bg-blue-50 dark:bg-slate-900': !simple && (!color || color === 'blue'),
-            '-admonition-header-green text-green-600 bg-green-50 dark:bg-slate-900': !simple && color === 'green',
-            '-admonition-header-yellow text-amber-600 bg-amber-50 dark:bg-slate-900': !simple && color === 'yellow',
-            '-admonition-header-red text-red-600 bg-red-50 dark:bg-slate-900': !simple && color === 'red',
-            '-admonition-header-dropdown cursor-pointer hover:shadow-[inset_0_0_0px_30px_#00000003] dark:hover:shadow-[inset_0_0_0px_30px_#FFFFFF03]':
+            'text-blue-600 bg-blue-50 dark:bg-slate-900': !simple && (!color || color === 'blue'),
+            'text-green-600 bg-green-50 dark:bg-slate-900': !simple && color === 'green',
+            'text-amber-600 bg-amber-50 dark:bg-slate-900': !simple && color === 'yellow',
+            'text-red-600 bg-red-50 dark:bg-slate-900': !simple && color === 'red',
+            'cursor-pointer hover:shadow-[inset_0_0_0px_30px_#00000003] dark:hover:shadow-[inset_0_0_0px_30px_#FFFFFF03]':
               dropdown,
           })}
         >
@@ -209,7 +209,6 @@ export function Admonition({
               kind={kind ?? AdmonitionKind.note}
               className={classNames({
                 // Needed for simple!
-                // Not sure what exactly this defines, could be expanded
                 'text-blue-600': !color || color === 'blue',
                 'text-green-600': color === 'green',
                 'text-amber-600': color === 'yellow',
@@ -219,7 +218,7 @@ export function Admonition({
           )}
           <div
             className={classNames(
-              '-admonition-header-text text-neutral-900 dark:text-white grow self-center overflow-hidden break-words',
+              'text-neutral-900 dark:text-white grow self-center overflow-hidden break-words',
               { 'ml-4': hideIcon },
             )}
           >
@@ -236,7 +235,7 @@ export function Admonition({
           )}
         </HeaderElement>
       )}
-      <div className={classNames('-admonition-paragraph-text px-4', { 'py-1': !simple, 'details-body': dropdown })}>
+      <div className={classNames('px-4', { 'py-1': !simple, 'details-body': dropdown })}>
         {children}
       </div>
     </WrapperElement>

--- a/styles/jupyter.css
+++ b/styles/jupyter.css
@@ -15,7 +15,7 @@
 /* Here we use important to overwrite mt from typography.css */
 
 table.dataframe {
-  @apply border-none border-collapse border-spacing-0 text-black text-xs table-fixed m-0 !important;
+  @apply border-none border-collapse border-spacing-0 text-xs table-fixed m-0 !important;
 }
 
 .dataframe thead {

--- a/styles/jupyter.css
+++ b/styles/jupyter.css
@@ -15,7 +15,7 @@
 /* Here we use important to overwrite mt from typography.css */
 
 table.dataframe {
-  @apply border-none border-collapse border-spacing-0 text-xs table-fixed m-0 !important;
+  @apply border-none border-collapse text-black border-spacing-0 text-xs table-fixed !m-0;
 }
 
 .dataframe thead {

--- a/styles/jupyter.css
+++ b/styles/jupyter.css
@@ -1,41 +1,36 @@
 .font-system {
   font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
 }
+
 .jupyter-error {
-  background-color: rgb(255, 221, 221);
+  @apply bg-red-100;
 }
+
 /* Hide the output prompts from jupyter by default */
 .jp-OutputPrompt {
-  display: none;
+  @apply hidden;
 }
+
 /* Pandas tables */
 /* Here we use important to overwrite mt from typography.css */
+
 table.dataframe {
-  border: none;
-  border-collapse: collapse;
-  border-spacing: 0;
-  color: black;
-  font-size: 1em;
-  table-layout: fixed;
-  margin: 0 !important;
+  @apply border-none border-collapse border-spacing-0 text-black text-xs table-fixed m-0 !important;
 }
+
 .dataframe thead {
-  border-bottom: 1px solid black;
-  vertical-align: bottom;
+  @apply align-bottom border-b border-black;
 }
-.dataframe tr,
-.dataframe th,
-.dataframe td {
-  text-align: right;
-  vertical-align: middle;
-  padding: 0.5em 0.5em;
-  line-height: normal;
-  white-space: normal;
-  max-width: none;
-  border: none;
-}
+
 .dataframe th {
-  font-weight: bold;
+  @apply font-bold;
+}
+
+.dataframe td {
+  @apply p-2 leading-normal text-right whitespace-normal align-middle border-none max-w-none;
+}
+
+/* System to override the Jupyter colors depending on line parity */
 }
 .dataframe tbody tr:nth-child(odd) {
   background: #f5f5f5;

--- a/styles/jupyter.css
+++ b/styles/jupyter.css
@@ -31,12 +31,13 @@ table.dataframe {
 }
 
 /* System to override the Jupyter colors depending on line parity */
+
+.jp-OutputArea-output table tr:nth-child(odd) {
+  @apply bg-neutral-100 dark:bg-neutral-900 [&>*]:hover:bg-sky-100 [&>*]:dark:hover:bg-sky-950;
 }
-.dataframe tbody tr:nth-child(odd) {
-  background: #f5f5f5;
-}
-.dataframe tbody tr:hover {
-  background: rgba(66, 165, 245, 0.2);
+
+.jp-OutputArea-output table tr:nth-child(even) {
+  @apply bg-neutral-200 dark:bg-neutral-800 [&>*]:hover:bg-sky-100 [&>*]:dark:hover:bg-sky-950;
 }
 
 html.dark {


### PR DESCRIPTION
- Restructured the `jupyter.css` file to use Tailwind CSS
- Used the latter to apply different styles to the table depending on the theme, making it readable, fixing https://github.com/jupyter-book/mystmd/issues/1595
- Hovering over a row now highlights the entire row instead of just the header column of that row
- - Hovering over a table uses the same highlight color regardless of line parity within the [dark | light] theme

---

_Everything works on my end, but make sure to check everything carefully because this is my first PR within this repo; also, this is my first time using changesets so in case more details are necessary, do not hesitate to change something_

_(edit: thinking about it now, I would prefer the bullet points above to be appended to the changeset so that other people could more clearly see what has been fixed)_