### PR TITLE
🔧 Add dev watch script to @myst-theme/common package.json

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,6 +15,7 @@
     "lint:format": "prettier --check \"src/**/*.{ts,tsx,md}\"",
     "test": "vitest run",
     "test:watch": "vitest watch",
+    "dev": "npm-run-all --parallel \"build:* -- --watch\"",
     "build:esm": "tsc --project ./tsconfig.json --module Node16 --outDir dist --declaration",
     "build": "npm-run-all -l clean -p build:esm"
   },


### PR DESCRIPTION
@stefanv noticed changes inside the `common` package were not picked up when running in watch mode (i.e. `npm run dev`). They required a rebuild and restart of the theme server.

I think maybe this was just a small oversight: there is no `dev` script in the `common` `package.json`. This PR just adds the same watch command that is present in all other sub-packages. With this addition, changes to `common` seem to trigger a rebuild correctly now...