### PR TITLE
🫣 Fix primary sidebar & header not showing navigation buttons correctly when ToC is hidden

### DIFF
--- a/.changeset/silver-jeans-wonder.md
+++ b/.changeset/silver-jeans-wonder.md
@@ -1,0 +1,9 @@
+---
+'myst-to-react': patch
+'@myst-theme/jupyter': patch
+'@myst-theme/site': patch
+'@myst-theme/book': patch
+'@myst-theme/styles': patch
+---
+
+Fix primary sidebar & header not showing navigation buttons correctly when ToC is hidden

--- a/packages/site/src/components/Navigation/Navigation.tsx
+++ b/packages/site/src/components/Navigation/Navigation.tsx
@@ -82,7 +82,11 @@ export const ConfigurablePrimaryNavigation = ({
 
   // the logic on the following line looks wrong, this will return `null` or `<></>`
   // we should just return `null` if `hide_toc` is true?
-  if (hide_toc) return children ? null : <>{children}</>;
+  if (!nav && hide_toc) return children ? null : <>{children}</>;
+  if (nav && hide_toc) {
+    headings = undefined;
+    footer = null;
+  }
 
   return (
     <>
@@ -98,6 +102,7 @@ export const ConfigurablePrimaryNavigation = ({
         nav={nav}
         headings={headings}
         footer={footer}
+        hide_toc={hide_toc}
         mobileOnly={mobileOnly}
       />
       {children}

--- a/packages/site/src/components/Navigation/PrimarySidebar.tsx
+++ b/packages/site/src/components/Navigation/PrimarySidebar.tsx
@@ -84,7 +84,7 @@ export function SidebarNavItem({ item }: { item: SiteNavItem }) {
 export function SidebarNav({ nav }: { nav?: SiteManifest['nav'] }) {
   if (!nav) return null;
   return (
-    <div className="w-full px-1 dark:text-white">
+    <div className="w-full px-1 dark:text-white font-medium">
       {nav.map((item) => {
         return <SidebarNavItem key={'url' in item ? item.url : item.title} item={item} />;
       })}
@@ -126,12 +126,14 @@ export const PrimarySidebar = ({
   nav,
   footer,
   headings,
+  hide_toc,
   mobileOnly,
 }: {
   sidebarRef?: React.RefObject<HTMLElement>;
   nav?: SiteManifest['nav'];
   headings?: Heading[];
   footer?: React.ReactNode;
+  hide_toc?: boolean;
   mobileOnly?: boolean;
 }) => {
   const top = useThemeTop();
@@ -156,6 +158,7 @@ export const PrimarySidebar = ({
         'fixed',
         `xl:${grid}`, // for example, xl:article-grid
         'grid-gap xl:w-screen xl:pointer-events-none overflow-auto max-xl:min-w-[300px]',
+        {'lg:hidden' : nav && hide_toc},
         { hidden: !open, 'z-30': open, 'z-10': !open },
       )}
       style={{ top }}

--- a/packages/site/src/components/Navigation/PrimarySidebar.tsx
+++ b/packages/site/src/components/Navigation/PrimarySidebar.tsx
@@ -158,7 +158,7 @@ export const PrimarySidebar = ({
         'fixed',
         `xl:${grid}`, // for example, xl:article-grid
         'grid-gap xl:w-screen xl:pointer-events-none overflow-auto max-xl:min-w-[300px]',
-        {'lg:hidden' : nav && hide_toc},
+        { 'lg:hidden': nav && hide_toc },
         { hidden: !open, 'z-30': open, 'z-10': !open },
       )}
       style={{ top }}

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -112,7 +112,20 @@ export function TopNav({ hideToc, hideSearch }: { hideToc?: boolean; hideSearch?
     <div className="bg-white/80 backdrop-blur dark:bg-stone-900/80 shadow dark:shadow-stone-700 p-3 md:px-8 sticky w-screen top-0 z-30 h-[60px]">
       <nav className="flex items-center justify-between flex-nowrap max-w-[1440px] mx-auto">
         <div className="flex flex-row xl:min-w-[19.5rem] mr-2 sm:mr-7 justify-start items-center shrink-0">
-          {!hideToc && (
+          {(nav && hideToc) && (
+            <div className="block lg:hidden">
+              <button
+                className="flex items-center border-stone-400 text-stone-800 hover:text-stone-900 dark:text-stone-200 hover:dark:text-stone-100"
+                onClick={() => {
+                  setOpen(!open);
+                }}
+              >
+                <MenuIcon width="2rem" height="2rem" className="m-1" />
+                <span className="sr-only">Open Menu</span>
+              </button>
+            </div>
+          )}
+          {(!nav || !hideToc) && (
             <div className="block xl:hidden">
               <button
                 className="flex items-center border-stone-400 text-stone-800 hover:text-stone-900 dark:text-stone-200 hover:dark:text-stone-100"

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -112,8 +112,13 @@ export function TopNav({ hideToc, hideSearch }: { hideToc?: boolean; hideSearch?
     <div className="bg-white/80 backdrop-blur dark:bg-stone-900/80 shadow dark:shadow-stone-700 p-3 md:px-8 sticky w-screen top-0 z-30 h-[60px]">
       <nav className="flex items-center justify-between flex-nowrap max-w-[1440px] mx-auto">
         <div className="flex flex-row xl:min-w-[19.5rem] mr-2 sm:mr-7 justify-start items-center shrink-0">
-          {(
-            <div className={classNames("block", {"lg:hidden": (nav && hideToc), "xl:hidden": !(nav && hideToc)})}>
+          {
+            <div
+              className={classNames('block', {
+                'lg:hidden': nav && hideToc,
+                'xl:hidden': !(nav && hideToc),
+              })}
+            >
               <button
                 className="flex items-center border-stone-400 text-stone-800 hover:text-stone-900 dark:text-stone-200 hover:dark:text-stone-100"
                 onClick={() => {
@@ -124,7 +129,7 @@ export function TopNav({ hideToc, hideSearch }: { hideToc?: boolean; hideSearch?
                 <span className="sr-only">Open Menu</span>
               </button>
             </div>
-          )}
+          }
           <HomeLink name={title} logo={logo} logoDark={logo_dark} logoText={logo_text} />
         </div>
         <div className="flex items-center flex-grow w-auto">

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -112,21 +112,8 @@ export function TopNav({ hideToc, hideSearch }: { hideToc?: boolean; hideSearch?
     <div className="bg-white/80 backdrop-blur dark:bg-stone-900/80 shadow dark:shadow-stone-700 p-3 md:px-8 sticky w-screen top-0 z-30 h-[60px]">
       <nav className="flex items-center justify-between flex-nowrap max-w-[1440px] mx-auto">
         <div className="flex flex-row xl:min-w-[19.5rem] mr-2 sm:mr-7 justify-start items-center shrink-0">
-          {nav && hideToc && (
-            <div className="block lg:hidden">
-              <button
-                className="flex items-center border-stone-400 text-stone-800 hover:text-stone-900 dark:text-stone-200 hover:dark:text-stone-100"
-                onClick={() => {
-                  setOpen(!open);
-                }}
-              >
-                <MenuIcon width="2rem" height="2rem" className="m-1" />
-                <span className="sr-only">Open Menu</span>
-              </button>
-            </div>
-          )}
-          {(!nav || !hideToc) && (
-            <div className="block xl:hidden">
+          {(
+            <div className={classNames("block", {"lg:hidden": (nav && hideToc), "xl:hidden": !(nav && hideToc)})}>
               <button
                 className="flex items-center border-stone-400 text-stone-800 hover:text-stone-900 dark:text-stone-200 hover:dark:text-stone-100"
                 onClick={() => {

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -112,7 +112,7 @@ export function TopNav({ hideToc, hideSearch }: { hideToc?: boolean; hideSearch?
     <div className="bg-white/80 backdrop-blur dark:bg-stone-900/80 shadow dark:shadow-stone-700 p-3 md:px-8 sticky w-screen top-0 z-30 h-[60px]">
       <nav className="flex items-center justify-between flex-nowrap max-w-[1440px] mx-auto">
         <div className="flex flex-row xl:min-w-[19.5rem] mr-2 sm:mr-7 justify-start items-center shrink-0">
-          {(nav && hideToc) && (
+          {nav && hideToc && (
             <div className="block lg:hidden">
               <button
                 className="flex items-center border-stone-400 text-stone-800 hover:text-stone-900 dark:text-stone-200 hover:dark:text-stone-100"


### PR DESCRIPTION
Fixes these issues:

- fixes https://github.com/jupyter-book/myst-theme/issues/462
- fixes https://github.com/jupyter-book/myst-theme/issues/514
- fixes https://github.com/jupyter-book/myst-theme/issues/601
- Makes text styling consistent (text-medium) in primary nav to ensure parity with top nav 

Given what was discussed in #458 by @agoose77 and @stevejpurves:

> 1. Users have a ToC, and maybe have a nav. They want the primary sidebar to be visible at all times (either as a drawer, or fixed on the page). They want the burger menu to appear only when the sidebar behaves as a drawer.
> 2. Users don't have a ToC, and have a nav. They want to hide_toc so that the primary sidebar is not visible unless the primary nav needs to be folded into the sidebar. They want the burger menu to appear when the sidebar is visible and acting as a drawer.
> 3. Users don't have a ToC or a nav. They never want to see the primary sidebar or burger menu.

all these states are accounted for in this PR (please, check!); thus, it should

- fixes https://github.com/jupyter-book/myst-theme/issues/458