### PR TITLE
✍️ Fix missing class name for `image` renderer

### DIFF
--- a/.changeset/great-buckets-hammer.md
+++ b/.changeset/great-buckets-hammer.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Fix missing classname for image

--- a/packages/myst-to-react/src/image.tsx
+++ b/packages/myst-to-react/src/image.tsx
@@ -121,6 +121,8 @@ function Picture({
       src={src}
       alt={alt}
       data-canonical-url={urlSource}
+      // Don't set className if nested under picture
+      className={srcOptimized ? undefined : className}
     />
   );
   if (!srcOptimized) return image;


### PR DESCRIPTION
This PR updates the early-return case in the component for rendering `image` nodes such that it includes a class name.

Fixes #625