### PR TITLE
⌨️ Cell block overflow color and copy icon location

### DIFF
--- a/.changeset/calm-rules-rescue.md
+++ b/.changeset/calm-rules-rescue.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Fix code block cell background color stops for long lines and copy icon positioning

--- a/packages/myst-to-react/src/code.tsx
+++ b/packages/myst-to-react/src/code.tsx
@@ -85,10 +85,10 @@ export function CodeBlock(props: Props) {
   return (
     <div
       id={identifier}
-      className={classNames('myst-code relative group not-prose overflow-auto', className, {
-        'shadow hover:shadow-md dark:shadow-2xl dark:shadow-neutral-900 my-5 text-sm': shadow,
+      className={classNames('relative myst-code group not-prose', className, {
+        'my-5 text-sm shadow hover:shadow-md dark:shadow-2xl dark:shadow-neutral-900': shadow,
         'bg-stone-200/10': background,
-        'border border-l-4 border-l-blue-400 border-gray-200 dark:border-l-blue-400 dark:border-gray-800':
+        'border border-l-4 border-gray-200 border-l-blue-400 dark:border-l-blue-400 dark:border-gray-800':
           border,
       })}
     >
@@ -97,20 +97,23 @@ export function CodeBlock(props: Props) {
           <DocumentIcon
             width="16px"
             height="16px"
-            className="myst-code-filename-icon self-center flex-none inline-block text-gray-500 dark:text-gray-100"
+            className="inline-block flex-none self-center text-gray-500 myst-code-filename-icon dark:text-gray-100"
           />
-          <div className="myst-code-filename-title self-center p-2 text-sm leading-3 prose text-slate-600 dark:text-white">
+          <div className="self-center p-2 text-sm leading-3 myst-code-filename-title prose text-slate-600 dark:text-white">
             {filename}
           </div>
         </div>
       )}
-      <SyntaxHighlighter {...highlighterProps} className="myst-code-body block p-3 hljs">
+      <SyntaxHighlighter
+        {...highlighterProps}
+        className="block overflow-auto p-3 myst-code-body hljs"
+      >
         {value}
       </SyntaxHighlighter>
       {showCopy && (
         <CopyIcon
           text={value}
-          className={classNames('myst-code-copy-icon absolute right-1', {
+          className={classNames('absolute right-1 myst-code-copy-icon', {
             'top-[32px]': filename,
             'top-1': !filename,
           })}


### PR DESCRIPTION
Fixes jupyter-book/mystmd#2145

@matthewfeickert this should fix things for the background, as well as the location of the copy-icon when you are scrolling.

Before:
![image](https://github.com/user-attachments/assets/4a49abea-b434-408f-aa17-3148fa286237)

After:
![image](https://github.com/user-attachments/assets/73bebff1-ba11-4646-94c4-c63adc03830a)