### PR TITLE
Fix accessibility bugs in search form dialog

### DIFF
--- a/.changeset/five-toys-float.md
+++ b/.changeset/five-toys-float.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/search': minor
+---
+
+Fix accessibility bugs in search form dialog

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -508,6 +508,7 @@ function SearchForm({
         <div className="relative flex w-full h-10 flow-row gap-x-1 ">
           <label id={searchLabelID} htmlFor={searchInputID}>
             <MagnifyingGlassIcon className="absolute text-gray-400 inset-y-0 start-0 h-10 w-10 p-2.5 aspect-square flex items-center pointer-events-none" />
+            <span className="hidden">Search query</span>
           </label>
           <input
             autoComplete="off"

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -506,7 +506,7 @@ function SearchForm({
     <>
       <form onSubmit={onSubmit}>
         <div className="relative flex w-full h-10 flow-row gap-x-1 ">
-          <label id={searchListID} htmlFor={searchInputID}>
+          <label id={searchLabelID} htmlFor={searchInputID}>
             <MagnifyingGlassIcon className="absolute text-gray-400 inset-y-0 start-0 h-10 w-10 p-2.5 aspect-square flex items-center pointer-events-none" />
           </label>
           <input


### PR DESCRIPTION
When the search form dialog is open (in the book theme), WAVE reports two accessibility errors:

1. The `input` element's `aria-labelledby` refers to a non-existent element `search-label`.
2. The `label` element is empty (no text, only an SVG magnifying glass icon).

This patch fixes both issues with accessibility in the search dialog by:

1. Correcting the `label` element's `id` to be `search-label`, rather than `search-list`. This seems to have been a typo since there is another element `search-list` that is used to present the list of search results.
2. The `label` element now has a hidden `span` with the text "Search query".