### PR TITLE
Rename XIcon to TwitterIcon from scienceicons

### DIFF
--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import type { ExpandedThebeFrontmatter, PageFrontmatter } from 'myst-frontmatter';
 import { SourceFileKind } from 'myst-spec-ext';
-import { OpenAccessIcon, GithubIcon, XIcon } from '@scienceicons/react/24/solid';
+import { OpenAccessIcon, GithubIcon, TwitterIcon } from '@scienceicons/react/24/solid';
 import { LicenseBadges } from './licenses.js';
 import { DownloadsDropdown } from './downloads.js';
 import { AuthorAndAffiliations, AuthorsList } from './Authors.js';
@@ -105,7 +105,7 @@ export function TwitterLink({ twitter: possibleLink }: { twitter?: string }) {
       rel="noopener noreferrer"
       className="text-inherit hover:text-inherit"
     >
-      <XIcon
+      <TwitterIcon
         width="1.25rem"
         height="1.25rem"
         className="inline-block mr-1 opacity-60 hover:opacity-100"


### PR DESCRIPTION
This is breaking a bunch of in-progress PRs, so I thought I'd just fix it as an independent PR. THe package "scienceicons" seems to have renamed XIcon to TwitterIcon - I'm not sure why else this would randomly change. This just makes that rename here