### PR TITLE
Delete visual reference

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,8 +1,0 @@
----
-title: Visual Reference
-description: Quick visual reference for myst-theme UI elements
----
-
-# Visual Reference
-
-This section provides a comprehensive visual reference showing how common document elements render in myst-theme. Use these pages to quickly see what any element looks like.


### PR DESCRIPTION
This just removes the top `Visual Reference` page from that section since it bugged both @stefanv and @bsipocz 😅

We can't include the _content_ of the visual reference in the dropdown header because we're using `glob` patterns to grab all the files in the folder. So we'd either need to rename the top file and make it useful, or just remove it for now, so I'm opting for the latter 