### PR TITLE
Fix whitespace of nav components

### DIFF
--- a/packages/site/src/components/Navigation/HomeLink.tsx
+++ b/packages/site/src/components/Navigation/HomeLink.tsx
@@ -25,8 +25,8 @@ export function HomeLink({
     >
       {logo && (
         <div
-          className={classNames('myst-home-link-logo p-1 mr-3', {
-            'dark:bg-white dark:rounded': !logoDark,
+          className={classNames('myst-home-link-logo mr-3 flex items-center', {
+            'dark:bg-white dark:rounded px-1': !logoDark,
           })}
         >
           <img

--- a/packages/site/src/components/Navigation/ThemeButton.tsx
+++ b/packages/site/src/components/Navigation/ThemeButton.tsx
@@ -3,7 +3,7 @@ import { MoonIcon } from '@heroicons/react/24/solid';
 import { SunIcon } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
 
-export function ThemeButton({ className = 'w-8 h-8 mx-3' }: { className?: string }) {
+export function ThemeButton({ className = 'w-10 h-10 mx-3' }: { className?: string }) {
   const { nextTheme } = useThemeSwitcher();
   return (
     <button

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -127,12 +127,12 @@ export function TopNav({ hideToc, hideSearch }: { hideToc?: boolean; hideSearch?
               })}
             >
               <button
-                className="myst-top-nav-menu-button flex items-center border-stone-400 text-stone-800 hover:text-stone-900 dark:text-stone-200 hover:dark:text-stone-100"
+                className="myst-top-nav-menu-button flex items-center justify-center border-stone-400 text-stone-800 hover:text-stone-900 dark:text-stone-200 hover:dark:text-stone-100 w-10 h-10"
                 onClick={() => {
                   setOpen(!open);
                 }}
               >
-                <MenuIcon width="2rem" height="2rem" className="m-1" />
+                <MenuIcon width="1.5rem" height="1.5rem" />
                 <span className="sr-only">Open Menu</span>
               </button>
             </div>


### PR DESCRIPTION
The navigation bar whitepace is slightly not vertically symmetric. This is annoying for people who are weirdly pedantic about this kind of thing, like me. I tried futzing with the CSS classes a bunch and this seemed to improve it. Here are GIFs of before and after.

![CleanShot 2025-11-21 at 16 48 12](https://github.com/user-attachments/assets/82f071f5-59d9-413b-85f3-ba76c44c49fb)

![CleanShot 2025-11-21 at 16 47 27](https://github.com/user-attachments/assets/bb1e0a34-2702-411e-b763-34f0d70e5265)
