### PR TITLE
👮some basic validation patterns and validating `output`

### DIFF
--- a/.changeset/bold-tires-warn.md
+++ b/.changeset/bold-tires-warn.md
@@ -1,0 +1,6 @@
+---
+'myst-to-react': patch
+'@myst-theme/jupyter': patch
+---
+
+Adds frontend validation utility functions and components and uses these at key points intended to prevent full page fatal errors when a particular renderer fails becuase the AST structure does not conform to expectations. Some generic malformed node handling is added so far and a specific case for `output` nodes.

--- a/packages/jupyter/src/safe.tsx
+++ b/packages/jupyter/src/safe.tsx
@@ -46,6 +46,12 @@ function OutputImage({ image, text }: { image: MinifiedMimePayload; text?: Minif
 }
 
 export function SafeOutput({ output }: { output: MinifiedOutput }) {
+  // Additional safety check
+  if (!output || !output.output_type) {
+    console.warn('SafeOutput received invalid output:', output);
+    return null;
+  }
+
   switch (output.output_type) {
     case 'stream':
       return (

--- a/packages/myst-to-react/src/MyST.tsx
+++ b/packages/myst-to-react/src/MyST.tsx
@@ -2,8 +2,40 @@ import { matches } from 'unist-util-select';
 import type { NodeRenderersValidated } from '@myst-theme/providers';
 import { useNodeRenderers } from '@myst-theme/providers';
 import type { GenericNode } from 'myst-common';
+import { ASTError } from './astError.js';
 
 function DefaultComponent({ node, className }: { node: GenericNode; className?: string }) {
+  // Validate the node has basic required properties
+  if (!node || typeof node !== 'object') {
+    return (
+      <ASTError
+        node={node as GenericNode}
+        title="Invalid AST Node"
+        message="Encountered a malformed AST node that is not a valid object."
+        debugHints={[
+          'This usually indicates a parsing or serialization error.',
+          'Check the content source for syntax errors.',
+          'Verify that the AST was generated correctly.',
+        ]}
+      />
+    );
+  }
+
+  if (!node.type) {
+    return (
+      <ASTError
+        node={node}
+        title="Missing Node Type"
+        message="AST node is missing the required 'type' property."
+        debugHints={[
+          'Every AST node must have a type property.',
+          'This may indicate corrupted or incomplete AST data.',
+          'Check the content processing pipeline for errors.',
+        ]}
+      />
+    );
+  }
+
   if (!node.children) return <span className={className}>{node.value}</span>;
   return (
     <div className={className}>
@@ -29,16 +61,70 @@ export function MyST({
 }) {
   const renderers = useNodeRenderers();
   if (!ast) return null;
+
+  // Handle single node
   if (!Array.isArray(ast)) {
-    const Component = selectRenderer(renderers, ast);
-    return <Component key={ast.key} node={ast} className={className} />;
+    try {
+      const Component = selectRenderer(renderers, ast);
+      return <Component key={ast.key} node={ast} className={className} />;
+    } catch (error) {
+      return (
+        <ASTError
+          node={ast}
+          title="Rendering Error"
+          message={`Failed to render AST node: ${error instanceof Error ? error.message : 'Unknown error'}`}
+          debugHints={[
+            'This node caused an error during rendering.',
+            'Check if the node type is supported by your renderer configuration.',
+            'Verify that the node has all required properties for its type.',
+          ]}
+        />
+      );
+    }
   }
+
+  // Handle array of nodes
   if (ast.length === 0) return null;
+
   return (
     <>
-      {ast?.map((node) => {
-        const Component = selectRenderer(renderers, node);
-        return <Component key={node.key} node={node} className={className} />;
+      {ast.map((node, index) => {
+        // Validate each node in the array
+        if (!node || typeof node !== 'object') {
+          const dummyNode = { type: 'invalid', key: `invalid-${index}` } as GenericNode;
+          return (
+            <ASTError
+              key={`error-${index}`}
+              node={dummyNode}
+              title="Invalid Array Node"
+              message={`Array contains invalid node at index ${index}.`}
+              debugHints={[
+                'Arrays of AST nodes should only contain valid node objects.',
+                'Check for null, undefined, or primitive values in the array.',
+                'This may indicate a problem with AST generation or serialization.',
+              ]}
+            />
+          );
+        }
+
+        try {
+          const Component = selectRenderer(renderers, node);
+          return <Component key={node.key || `node-${index}`} node={node} className={className} />;
+        } catch (error) {
+          return (
+            <ASTError
+              key={`error-${node.key || index}`}
+              node={node}
+              title="Rendering Error"
+              message={`Failed to render AST node: ${error instanceof Error ? error.message : 'Unknown error'}`}
+              debugHints={[
+                'This node caused an error during rendering.',
+                'Check if the node type is supported by your renderer configuration.',
+                'Verify that the node has all required properties for its type.',
+              ]}
+            />
+          );
+        }
       })}
     </>
   );

--- a/packages/myst-to-react/src/astError.tsx
+++ b/packages/myst-to-react/src/astError.tsx
@@ -1,0 +1,257 @@
+import { ExclamationTriangleIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
+import classNames from 'classnames';
+import type { GenericNode } from 'myst-common';
+import {
+  validateASTNode,
+  generateDebuggingHints,
+  type ASTValidationResult,
+} from './astValidation.js';
+
+interface ASTErrorProps {
+  node: GenericNode;
+  title: string;
+  message?: string;
+  className?: string;
+  showNodeInfo?: boolean;
+  debugHints?: string[];
+}
+
+function SourceInformation({ sourceInfo }: { sourceInfo: any }) {
+  const hasSourceInfo = sourceInfo.label || sourceInfo.url || sourceInfo.title;
+
+  if (!hasSourceInfo) return null;
+
+  return (
+    <div className="p-3 bg-red-100 rounded border border-red-200 dark:bg-red-900/30 dark:border-red-700">
+      <h5 className="mb-2 text-sm font-medium text-red-800 dark:text-red-200">
+        Source Information
+      </h5>
+      <div className="grid grid-cols-1 gap-1 text-sm">
+        {sourceInfo.label && (
+          <div>
+            <span className="font-medium text-red-700 dark:text-red-300">Label:</span>{' '}
+            <code className="px-1 text-red-800 bg-red-200 rounded dark:text-red-200 dark:bg-red-800/30">
+              {sourceInfo.label}
+            </code>
+          </div>
+        )}
+        {sourceInfo.url && (
+          <div>
+            <span className="font-medium text-red-700 dark:text-red-300">URL:</span>{' '}
+            <code className="px-1 text-red-800 bg-red-200 rounded dark:text-red-200 dark:bg-red-800/30">
+              {sourceInfo.url}
+            </code>
+          </div>
+        )}
+        {sourceInfo.title && (
+          <div>
+            <span className="font-medium text-red-700 dark:text-red-300">Title:</span>{' '}
+            <span className="dark:text-red-200">{sourceInfo.title}</span>
+          </div>
+        )}
+        {sourceInfo.remoteBaseUrl && (
+          <div>
+            <span className="font-medium text-red-700 dark:text-red-300">Remote Base:</span>{' '}
+            <code className="px-1 text-red-800 bg-red-200 rounded dark:text-red-200 dark:bg-red-800/30">
+              {sourceInfo.remoteBaseUrl}
+            </code>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ASTNodeInformation({ node }: { node: GenericNode }) {
+  return (
+    <div className="p-3 bg-gray-100 rounded border border-gray-200 dark:bg-gray-800 dark:border-gray-600">
+      <h5 className="mb-2 text-sm font-medium text-gray-800 dark:text-gray-200">
+        AST Node Information
+      </h5>
+      <div className="grid grid-cols-1 gap-1 text-sm">
+        <div>
+          <span className="font-medium text-gray-700 dark:text-gray-300">Type:</span>{' '}
+          <code className="px-1 text-gray-800 bg-gray-200 rounded dark:text-gray-200 dark:bg-gray-700">
+            {node.type}
+          </code>
+        </div>
+        {node.key && (
+          <div>
+            <span className="font-medium text-gray-700 dark:text-gray-300">Key:</span>{' '}
+            <code className="px-1 text-gray-800 bg-gray-200 rounded dark:text-gray-200 dark:bg-gray-700">
+              {node.key}
+            </code>
+          </div>
+        )}
+        {node.position && (
+          <div>
+            <span className="font-medium text-gray-700 dark:text-gray-300">Position:</span>{' '}
+            <span className="dark:text-gray-200">
+              Line {node.position.start?.line || 'unknown'}
+            </span>
+          </div>
+        )}
+        <div>
+          <span className="font-medium text-gray-700 dark:text-gray-300">Has Children:</span>{' '}
+          <span className="dark:text-gray-200">
+            {node.children ? `Yes (${node.children.length})` : 'No'}
+          </span>
+        </div>
+        {node.value && (
+          <div>
+            <span className="font-medium text-gray-700 dark:text-gray-300">Value:</span>{' '}
+            <code className="px-1 text-xs text-gray-800 bg-gray-200 rounded dark:text-gray-200 dark:bg-gray-700">
+              {typeof node.value === 'string'
+                ? node.value.length > 50
+                  ? node.value.substring(0, 50) + '...'
+                  : node.value
+                : JSON.stringify(node.value)}
+            </code>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ValidationResults({ validationResult }: { validationResult: ASTValidationResult }) {
+  if (validationResult.errors.length === 0 && validationResult.warnings.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      {validationResult.errors.length > 0 && (
+        <div className="p-3 bg-red-100 rounded border border-red-300 dark:bg-red-900/30 dark:border-red-700">
+          <h5 className="mb-2 text-sm font-medium text-red-800 dark:text-red-200">
+            Validation Errors
+          </h5>
+          <ul className="space-y-1 text-sm text-red-700 dark:text-red-300">
+            {validationResult.errors.map((error, index) => (
+              <li key={index} className="flex gap-1 items-start">
+                <span className="flex-shrink-0 text-red-500 dark:text-red-400">•</span>
+                <span>{error}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {validationResult.warnings.length > 0 && (
+        <div className="p-3 bg-yellow-50 rounded border border-yellow-300 dark:bg-yellow-900/20 dark:border-yellow-600">
+          <h5 className="mb-2 text-sm font-medium text-yellow-800 dark:text-yellow-200">
+            Validation Warnings
+          </h5>
+          <ul className="space-y-1 text-sm text-yellow-700 dark:text-yellow-300">
+            {validationResult.warnings.map((warning, index) => (
+              <li key={index} className="flex gap-1 items-start">
+                <span className="flex-shrink-0 text-yellow-500 dark:text-yellow-400">•</span>
+                <span>{warning}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DebuggingHints({ hints }: { hints: string[] }) {
+  if (hints.length === 0) return null;
+
+  return (
+    <div className="p-3 bg-blue-50 rounded border border-blue-200 dark:bg-blue-900/20 dark:border-blue-700">
+      <div className="flex gap-2 items-center mb-2">
+        <InformationCircleIcon className="flex-shrink-0 w-4 h-4 text-blue-600 dark:text-blue-400" />
+        <h5 className="text-sm font-medium text-blue-800 dark:text-blue-200">Debugging Hints</h5>
+      </div>
+      <ul className="space-y-1 text-sm text-blue-700 dark:text-blue-300">
+        {hints.map((hint, index) => (
+          <li key={index} className="flex gap-1 items-start">
+            <span className="flex-shrink-0 text-blue-500 dark:text-blue-400">•</span>
+            <span>{hint}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function RawASTData({ node }: { node: GenericNode }) {
+  return (
+    <div className="rounded border border-gray-300 dark:border-gray-600">
+      <div className="p-3 text-sm font-medium text-gray-600 bg-gray-100 rounded-t cursor-pointer dark:text-gray-300 dark:bg-gray-800 hover:text-gray-800 dark:hover:text-gray-100">
+        Raw AST Node Data
+      </div>
+      <pre className="overflow-x-auto p-3 mt-0 text-xs text-gray-900 bg-gray-100 rounded-b border-t border-gray-300 dark:bg-gray-900 dark:text-gray-100 dark:border-gray-600">
+        {JSON.stringify(node, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+export function ASTError({
+  node,
+  title,
+  message,
+  className,
+  showNodeInfo = true,
+  debugHints = [],
+}: ASTErrorProps) {
+  const sourceInfo = node?.source || {};
+  const hasSourceInfo = sourceInfo.label || sourceInfo.url || sourceInfo.title;
+
+  // Perform validation and get automatic hints
+  const validationResult = validateASTNode(node);
+  const autoHints = generateDebuggingHints(node);
+  const allHints = [...debugHints, ...autoHints];
+
+  return (
+    <div
+      className={classNames(
+        'p-4 my-4 bg-red-50 rounded border border-red-300 dark:bg-red-900/20 dark:border-red-700',
+        className,
+      )}
+      role="alert"
+    >
+      {/* Header with Icon and Title */}
+      <div className="flex gap-2 items-start mb-2">
+        <ExclamationTriangleIcon className="w-5 h-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+        <div className="text-base font-semibold text-red-800 dark:text-red-200">{title}</div>
+      </div>
+      <div className="flex gap-2 items-start mb-2">
+        {message && <p className="mt-1 text-sm text-red-700 dark:text-red-300">{message}</p>}
+      </div>
+
+      {/* Compact Source Information */}
+      {hasSourceInfo && sourceInfo.label && (
+        <div className="mb-3">
+          <span className="text-sm font-medium text-red-800 dark:text-red-200">Source: </span>
+          <code className="px-2 py-1 text-sm text-red-800 bg-red-200 rounded dark:text-red-200 dark:bg-red-800/30">
+            {sourceInfo.label}
+          </code>
+        </div>
+      )}
+
+      {/* Expandable Details */}
+      <details className="mt-3">
+        <summary className="flex gap-1 items-center text-sm font-medium text-red-700 cursor-pointer dark:text-red-300 hover:text-red-800 dark:hover:text-red-200">
+          <span>Show debugging information</span>
+          <span className="text-xs text-red-500 dark:text-red-400">▼</span>
+        </summary>
+
+        <div className="mt-3 space-y-3">
+          <SourceInformation sourceInfo={sourceInfo} />
+
+          {showNodeInfo && <ASTNodeInformation node={node} />}
+
+          <ValidationResults validationResult={validationResult} />
+
+          <DebuggingHints hints={allHints} />
+
+          <RawASTData node={node} />
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/packages/myst-to-react/src/astValidation.ts
+++ b/packages/myst-to-react/src/astValidation.ts
@@ -1,0 +1,185 @@
+import type { GenericNode } from 'myst-common';
+
+/**
+ * Validation result for AST nodes
+ */
+export interface ASTValidationResult {
+  isValid: boolean;
+  errors: string[];
+  warnings: string[];
+  nodeInfo?: {
+    type?: string;
+    hasChildren: boolean;
+    hasValue: boolean;
+    childrenCount?: number;
+    source?: any;
+  };
+}
+
+/**
+ * Validates a single AST node for common issues
+ */
+export function validateASTNode(node: any): ASTValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Basic existence check
+  if (!node) {
+    return {
+      isValid: false,
+      errors: ['Node is null or undefined'],
+      warnings: [],
+    };
+  }
+
+  // Type check
+  if (typeof node !== 'object') {
+    return {
+      isValid: false,
+      errors: [`Node is not an object (got ${typeof node})`],
+      warnings: [],
+    };
+  }
+
+  // Required type property
+  if (!node.type || typeof node.type !== 'string') {
+    errors.push('Node is missing required "type" property or type is not a string');
+  }
+
+  // Check for common problematic patterns
+  if (node.children === null) {
+    warnings.push('Node has null children (should be undefined or array)');
+  }
+
+  if (Array.isArray(node.children) && node.children.some((child: any) => !child)) {
+    warnings.push('Children array contains null/undefined values');
+  }
+
+  const nodeInfo = {
+    type: node.type,
+    hasChildren: Boolean(node.children),
+    hasValue: Boolean(node.value),
+    childrenCount: Array.isArray(node.children) ? node.children.length : undefined,
+    source: node.source,
+  };
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    warnings,
+    nodeInfo,
+  };
+}
+
+/**
+ * Validates an array of AST nodes
+ */
+export function validateASTArray(nodes: any[]): ASTValidationResult {
+  const allErrors: string[] = [];
+  const allWarnings: string[] = [];
+
+  if (!Array.isArray(nodes)) {
+    return {
+      isValid: false,
+      errors: ['Expected array but got ' + typeof nodes],
+      warnings: [],
+    };
+  }
+
+  nodes.forEach((node, index) => {
+    const result = validateASTNode(node);
+
+    result.errors.forEach((error) => {
+      allErrors.push(`Node ${index}: ${error}`);
+    });
+
+    result.warnings.forEach((warning) => {
+      allWarnings.push(`Node ${index}: ${warning}`);
+    });
+  });
+
+  return {
+    isValid: allErrors.length === 0,
+    errors: allErrors,
+    warnings: allWarnings,
+    nodeInfo: {
+      type: 'array',
+      hasChildren: nodes.length > 0,
+      hasValue: false,
+      childrenCount: nodes.length,
+    },
+  };
+}
+
+/**
+ * Gets debugging information for an AST node
+ */
+export function getASTDebugInfo(node: GenericNode): string[] {
+  const info: string[] = [];
+
+  if (!node) {
+    info.push('Node is null or undefined');
+    return info;
+  }
+
+  info.push(`Node type: ${node.type || 'undefined'}`);
+  info.push(
+    `Has children: ${Boolean(node.children)} ${node.children ? `(${node.children.length})` : ''}`,
+  );
+  info.push(`Has value: ${Boolean(node.value)}`);
+  info.push(`Has key: ${Boolean(node.key)}`);
+
+  if (node.position) {
+    info.push(`Position: Line ${node.position.start?.line || 'unknown'}`);
+  }
+
+  if (node.source) {
+    info.push(`Source label: ${node.source.label || 'none'}`);
+    info.push(`Source URL: ${node.source.url || 'none'}`);
+
+    if (node.source.remoteBaseUrl) {
+      info.push(`Remote base URL: ${node.source.remoteBaseUrl}`);
+    }
+  }
+
+  return info;
+}
+
+/**
+ * Generates debugging hints based on node characteristics
+ */
+export function generateDebuggingHints(node: GenericNode): string[] {
+  const hints: string[] = [];
+
+  if (!node) return ['Node is null or undefined - check AST generation'];
+
+  if (!node.type) {
+    hints.push('Node is missing type property - may be corrupted AST data');
+  }
+
+  if (node.type === 'embed') {
+    if (!node.children && node.source?.label?.startsWith('xref:local')) {
+      hints.push('Local cross-reference failed - check if content server is running');
+      hints.push('Verify CONTENT_CDN_PORT environment variable is set correctly');
+    }
+
+    if (!node.children && node.source?.label?.startsWith('xref:')) {
+      hints.push('External cross-reference failed - check network connectivity');
+      hints.push('Verify the target content exists and is accessible');
+    }
+
+    if (!node.children && !node.source) {
+      hints.push('Embed has no source or content - check MyST directive syntax');
+    }
+  }
+
+  if (node.children === null) {
+    hints.push('Children is explicitly null - should be undefined or an array');
+  }
+
+  if (Array.isArray(node.children) && node.children.length === 0 && node.type !== 'paragraph') {
+    hints.push('Node has empty children array - may be intentional or indicate missing content');
+  }
+
+  return hints;
+}

--- a/packages/myst-to-react/src/index.tsx
+++ b/packages/myst-to-react/src/index.tsx
@@ -28,6 +28,13 @@ export { CopyIcon, HoverPopover, Tooltip, LinkCard } from './components/index.js
 export { CodeBlock } from './code.js';
 export { HashLink, scrollToElement } from './hashLink.js';
 export { Admonition, AdmonitionKind } from './admonitions.js';
+export { ASTError } from './astError.js';
+export {
+  validateASTNode,
+  validateASTArray,
+  getASTDebugInfo,
+  generateDebuggingHints,
+} from './astValidation.js';
 export { Details } from './dropdown.js';
 export { TabSet, TabItem } from './tabs.js';
 export { useFetchMdast } from './crossReference.js';


### PR DESCRIPTION
Adds frontend validation utility functions and components and uses these at key points intended to prevent full page fatal errors when a particular renderer fails becuase the AST structure does not conform to expectations. Some generic malformed node handling is added so far and a specific case for `output` nodes.

## Motivation

* I added this after seeing full page fatal rendering errors because a particular NodeRenderer failed with an unknown exception on SSR
* In an eco system of growing plugins and NodeRenderers, we could consider some type of defensive validation at render time to prevent full page fatal crashes and surface relevant debug info

<img width="2486" height="1328" alt="image" src="https://github.com/user-attachments/assets/cbc0acd4-95c9-4b43-b5f5-31a7cbcd4fc1" />

<img width="1906" height="1768" alt="image" src="https://github.com/user-attachments/assets/5b166995-e1d6-4bf3-8283-ff62a3ecb1a1" />
