### PR TITLE
Add a github release maker workflow

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -1,0 +1,57 @@
+name: Publish GitHub Release
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for the release (e.g. myst-to-react@1.2.3)'
+        required: true
+        type: string
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      # Get the tag of the latest GitHub release
+      - name: Get previous release tag
+        id: previous_release
+        run: |
+          PREV_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install github-activity
+        run: pip install github-activity
+
+      # Generate release notes since the last release
+      - name: Generate release notes with github-activity
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          github-activity "$GITHUB_REPOSITORY" --since "${{ steps.previous_release.outputs.tag }}" > release-notes.md
+          # Remove the title from the release notes
+          tail -n +2 release-notes.md > release-notes-temp.md && mv release-notes-temp.md release-notes.md
+
+      # Create GitHub Release with gh
+      - name: Create GitHub Release with gh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.inputs.tag_name || inputs.tag_name }}"
+          gh release create "$TAG" --title "$TAG" --notes-file release-notes.md --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js 18.x
         uses: actions/setup-node@v3
@@ -22,6 +24,7 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run test
+      # Changesets action will set published=true if it does publish
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -48,3 +51,26 @@ jobs:
       - name: Deploy Article
         if: steps.changesets.outputs.published == 'true'
         run: make deploy-article
+
+  # Grab the tag from package.json so we know how to tag the github release
+  get-tag:
+    name: Get Tag Name
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.get_tag.outputs.tag_name }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+
+  # Trigger a github release workflow only if we've published
+  release-github:
+    name: Publish GitHub Release
+    needs:
+      - release
+      - get-tag
+    if: ${{ needs.release.outputs.published == 'true' }}
+    uses: ./.github/workflows/publish-github-release.yml
+    with:
+      tag_name: ${{ needs.get-tag.outputs.tag_name }}
+    secrets: inherit


### PR DESCRIPTION
This basically copies the pattern that we use in mystmd here:

https://github.com/jupyter-book/mystmd/blob/main/.github/workflows/publish-github-release.yml

It does the following:

- if changesets says we've published
- it grabs the tag of the current release using `package.json`
- it grabs the tag of the latest *github* release using the `gh` cli
- it generates a changelog using `github-activity` using `last-tag`
- it generates a github release using that changelog with `new-tag`