### PR TITLE
⌛️future proofing `migrate` calls

### DIFF
--- a/.changeset/whole-onions-rescue.md
+++ b/.changeset/whole-onions-rescue.md
@@ -1,0 +1,7 @@
+---
+'myst-to-react': patch
+'@myst-theme/article': patch
+'@myst-theme/book': patch
+---
+
+Use of `migrate()` updates to ensure full pass-through of the `PageLoader` data. At the moment `myst-migrate` only deals with `mdast` but in will likely deal with the entire page, this change enables that.

--- a/packages/myst-to-react/src/crossReference.tsx
+++ b/packages/myst-to-react/src/crossReference.tsx
@@ -26,11 +26,10 @@ const fetcher = (...args: Parameters<typeof fetch>): Promise<PageLoader> =>
     if (res.status === 200) {
       let data = (await res.json()) as PageLoader & { version?: number };
       try {
-        const { mdast, version } = await migrate(
+        data = (await migrate(
           { version: data.version ?? 0, ...data },
           { to: MYST_SPEC_VERSION },
-        );
-        data = { ...data, mdast, version } as PageLoader;
+        )) as PageLoader & { version: number };
       } catch (error) {
         console.error(`Error migrating content for ${args[0]} (aborted):`, error);
       }

--- a/themes/article/app/utils/loaders.server.ts
+++ b/themes/article/app/utils/loaders.server.ts
@@ -52,11 +52,10 @@ async function getStaticContent(project?: string, slug?: string): Promise<PageLo
   if (!response || response.status === 404) return null;
   let data = (await response.json()) as PageLoader & { version?: number };
   try {
-    const { mdast, version } = await migrate(
+    data = (await migrate(
       { version: data.version ?? 0, ...data },
       { to: MYST_SPEC_VERSION },
-    );
-    data = { ...data, mdast, version } as PageLoader;
+    )) as PageLoader & { version: number };
   } catch (error) {
     console.error(`Error migrating content for ${project}/${slug} (aborted):`, error);
   }

--- a/themes/book/app/utils/loaders.server.ts
+++ b/themes/book/app/utils/loaders.server.ts
@@ -54,11 +54,10 @@ async function getStaticContent(project?: string, slug?: string): Promise<PageLo
   if (!response || response.status === 404) return null;
   let data = (await response.json()) as PageLoader & { version?: number };
   try {
-    const { mdast, version } = await migrate(
+    data = (await migrate(
       { version: data.version ?? 0, ...data },
       { to: MYST_SPEC_VERSION },
-    );
-    data = { ...data, mdast, version } as PageLoader;
+    )) as PageLoader & { version: number };
   } catch (error) {
     console.error(`Error migrating content for ${project}/${slug} (aborted):`, error);
   }


### PR DESCRIPTION
This is a small, timely change to just tweak the migrate code that has been brought into the themes. What was there previously was working, but this change future-proofs it in terms of the full page loader data now flows through migrate, meaning that we can easily extend migrate to, for example, also address front matter changes without having to update these calls. 