### PR TITLE
feat: add route to handle static assets

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -11,6 +11,7 @@ export enum Theme {
 export enum ErrorStatus {
   noSite = 'Site was not found',
   noArticle = 'Article was not found',
+  noAsset = 'Static asset was not found',
 }
 
 export type Heading = {

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -131,6 +131,9 @@ export function updateSiteManifestStaticLinksInplace(
     if (!action.static) return;
     action.url = updateUrl(action.url);
   });
+  data.static?.forEach((asset) => {
+    asset.url = updateUrl(asset.url);
+  });
   // TODO: this needs to be based on the template.yml in the future
   // We have moved logo/logo_dark to options in v1.1.28
   data.options ??= {};

--- a/packages/site/src/loaders/errors.server.ts
+++ b/packages/site/src/loaders/errors.server.ts
@@ -15,3 +15,10 @@ export function responseNoArticle() {
     statusText: ErrorStatus.noArticle,
   });
 }
+
+export function responseNoAsset() {
+  return new Response(ErrorStatus.noAsset, {
+    status: 404,
+    statusText: ErrorStatus.noAsset,
+  });
+}

--- a/themes/article/app/routes/static.$.ts
+++ b/themes/article/app/routes/static.$.ts
@@ -1,0 +1,24 @@
+import { type LoaderFunction } from '@remix-run/node';
+import { getConfig, updateLink } from '~/utils/loaders.server';
+import { responseNoSite, responseNoAsset } from '@myst-theme/site';
+
+export const loader: LoaderFunction = async ({ params }) => {
+  const config = await getConfig();
+  if (!config) throw responseNoSite();
+  const slug = params['*'] as string;
+  if (!slug || slug === '') return responseNoAsset();
+  const staticFiles = config?.static?.filter(({ filename }) => filename.endsWith(slug));
+  if (!staticFiles || staticFiles.length === 0) return responseNoAsset();
+  const url = updateLink(staticFiles[0].url);
+  const response = await fetch(url).catch(() => null);
+  if (!response || response.status === 404) return null;
+  return new Response(response.body as any, {
+    status: 200,
+    headers: {
+      'Content-Type': response.headers.get('Content-Type') ?? 'application/octet-stream',
+      'Content-Length': response.headers.get('Content-Length') || '',
+      'Content-Disposition': `inline; filename="${staticFiles[0].url.split('/').pop()}"`,
+      'X-Remix-Resource': 'yes',
+    },
+  });
+};

--- a/themes/article/app/utils/loaders.server.ts
+++ b/themes/article/app/utils/loaders.server.ts
@@ -28,7 +28,7 @@ export async function getConfig(opts?: LinkRewriteOptions): Promise<SiteManifest
   return updateSiteManifestStaticLinksInplace(data, (url) => updateLink(url, opts));
 }
 
-function updateLink(
+export function updateLink(
   url: string,
   { rewriteStaticFolder = process.env.MODE === 'static' }: LinkRewriteOptions = {},
 ) {
@@ -44,6 +44,7 @@ function updateLink(
   }
   return `${CONTENT_CDN}${url}`;
 }
+
 async function getStaticContent(project?: string, slug?: string): Promise<PageLoader | null> {
   if (!slug) return null;
   const projectSlug = project ? `${project}/` : '';


### PR DESCRIPTION
A new route `/static/*` is added to retrieve assets configured as static in myst.yml.

See jupyter-book/mystmd#1921

TODO:

- [ ] Just return the raw response from the content server, no need to check if the path is configured since there's now the `/static` prefix to differentiate. This might mean that the content server needs to have a handler to handle the mapping from path -> hashed filename rather than handling it here.
- [ ] Tests
- [ ] Documentation