### PR TITLE
Use UV for pip install in dev docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,6 +14,6 @@
     npm run build && \
     # Install Python requirements and build docs
     pip install uv && \
-    uv pip install -r docs/requirements.txt --system && \
+    python -m uv pip install -r docs/requirements.txt --system && \
     make build-docs
   """


### PR DESCRIPTION
I noticed that the dev docs install took some time because of the computational dependencies in our examples. This PR sees if adding uv makes it faster.

Without this PR: 

<img width="1442" height="210" alt="CleanShot 2026-01-09 at 12 02 56@2x" src="https://github.com/user-attachments/assets/d9516a10-76d2-47c9-b96a-d9497267147b" />

With this PR:

<img width="1410" height="174" alt="CleanShot 2026-01-09 at 12 08 57@2x" src="https://github.com/user-attachments/assets/b7290d6b-ac0f-45d6-a1d4-c4c002435339" />

