### PR TITLE
Standardize link styles

### DIFF
--- a/.changeset/strong-spiders-beam.md
+++ b/.changeset/strong-spiders-beam.md
@@ -1,0 +1,8 @@
+---
+"myst-to-react": patch
+"@myst-theme/book": patch
+"@myst-theme/styles": patch
+"@myst-theme/docs": patch
+---
+
+Standardize link styles

--- a/docs/developer/local.md
+++ b/docs/developer/local.md
@@ -6,20 +6,31 @@ To interact with the themes in development mode (e.g. with live-reload of compon
 2. Theme: A dev server that watches for changes to this theme and re-builds it automatically.
 3. Theme: The theme server / renderer application.
 
-## First build a local version of the book theme
+## Initial setup
 
-Run this to build a local version of the book theme:
+First, install dependencies and build the packages:
 
 ```shell
-$ make build-book
+npm install
+npm run build
+```
+
+The build step compiles TypeScript for all packages in `packages/`. This is required before running the dev server or building themes.
+
+Then build a local version of the book theme:
+
+```shell
+make build-book
 ```
 
 This is a requirement of the way our static site is generated.
 It expects to find a built theme locally, and the `myst start --headless` command below will error if it isn't done at least once.
 
-## Start a content server
+## Preview changes locally
 
-First, start [a content server application](https://mystmd.org/guide/developer#content-server) in another MyST site. For example, with our docs:
+### Start a content server
+
+Start [a content server application](https://mystmd.org/guide/developer#content-server) in another MyST site. For example, with our docs:
 
 ```bash
 # Terminal 1
@@ -29,26 +40,25 @@ myst start --headless
 
 The content server parses MyST content into AST. By using `--headless`, we tell the content server **not** to start its own theme server.
 
-## Start a development server
+### Start a development server
 
-Next, start the dev server which will look for local changes and ensure they're being used in previews.
+Start the dev server which watches for local changes to packages:
 
 ```bash
 # Terminal 2
-npm install
 npm run dev
 ```
 
-## Start a theme server
+### Start a theme server
 
-Finally, start the theme server application, which will take the AST from the content server in Terminal 1 and render it for you to preview:
+Start the theme server application, which will take the AST from the content server and render it for you to preview:
 
 ```shell
 # Terminal 3
-$ npm run theme:book
+npm run theme:book
 ```
 
-## Preview your changes
+### Preview your changes
 
 Open the port that is printed in the terminal for your theme server (usually, `https://localhost:3000`). The theme server will start serving the AST from the content as a website at that port.
 
@@ -81,18 +91,12 @@ We have a lightweight [storybook](https://storybook.js.org/) configuration, whic
 
 This is the same tool that powers [the MyST Theme components documentation](https://jupyter-book.github.io/myst-theme/?path=/docs/components-introduction--docs).
 
-To use Storybook:
-
-First, run storybook:
+To use Storybook, first complete the [initial setup](#initial-setup), then run:
 
 ```shell
 # Terminal 1
 npm run storybook
-```
 
-Then, run a development server:
-
-```shell
-# Terminal2
-$ npm run dev
+# Terminal 2
+npm run dev
 ```

--- a/docs/reference/typography.md
+++ b/docs/reference/typography.md
@@ -60,37 +60,15 @@ Press {kbd}`Ctrl+C` to copy, {kbd}`Ctrl+V` to paste, or {kbd}`Ctrl+Alt+Delete` f
 
 The {smallcaps}`HTML` specification defines web standards.
 
-## Links
+## Links and terms
 
-### External Links
-
-External links open in a new tab and display a small icon to indicate they leave the current site.
-
-See [MyST Markdown](https://mystmd.org) for documentation.
-
-If they use a role or link that supports hover previews, they'll have a dotted line:
-
-[](https://doi.org/10.25080/hwcj9957)
-
-### Internal Links
-
-Have a solid underline if they don't have hover previews:
-
-Link to [](tables.md).
-
-Have a dotted underline if they have hover previews (e.g. for a label reference):
-
-Link to [](#math).
-
-### Hover-only links
-
-Hover-only links are black with a dotted line, for example:
-
-The HOVER will be black.
+- External link: [MyST Markdown](https://mystmd.org)
+- External link with hover: [](https://doi.org/10.25080/hwcj9957)
+- Internal link: [](tables.md)
+- Internal link with hover: [](#math)
+- Hover-only text: HOVER
 
 ## Buttons
-
-### Basic Button
 
 {button}`Click Me! <https://mystmd.org>`
 

--- a/docs/reference/typography.md
+++ b/docs/reference/typography.md
@@ -25,8 +25,8 @@ This is a second paragraph, separated from the first by a blank line. Paragraph 
 ### Bold and Italic
 
 - **This text is bold**
-- *This text is italic*
-- ***This text is bold and italic***
+- _This text is italic_
+- **_This text is bold and italic_**
 
 ### Underline and Strikethrough
 
@@ -97,6 +97,7 @@ The HOVER will be black.
 {button}`Click Me! <https://mystmd.org>`
 
 (math)=
+
 ## Math
 
 ### Inline Math
@@ -149,7 +150,7 @@ Content below the horizontal rule.
 
 ## Mixed Inline Elements
 
-This paragraph demonstrates **bold**, *italic*, ***bold italic***, `code`, [links](https://mystmd.org), math $x^2$, {kbd}`Ctrl+S`, H{sub}`2`O, x{sup}`2`, and {abbr}`API (Application Programming Interface)` all in one place.
+This paragraph demonstrates **bold**, _italic_, **_bold italic_**, `code`, [links](https://mystmd.org), math $x^2$, {kbd}`Ctrl+S`, H{sub}`2`O, x{sup}`2`, and {abbr}`API (Application Programming Interface)` all in one place.
 
 ## Long Words and Wrapping
 
@@ -171,10 +172,10 @@ Default paragraph with standard left alignment and natural text flow.
 
 ## Emphasis Combinations
 
-- *Italic with `code`*
+- _Italic with `code`_
 - **Bold with `code`**
-- ***Bold italic with `code`***
-- *Italic with [link](https://mystmd.org)*
+- **_Bold italic with `code`_**
+- _Italic with [link](https://mystmd.org)_
 - **Bold with [link](https://mystmd.org)**
 
 ## Numbers and Units
@@ -204,7 +205,7 @@ Regular paragraph continues here.
 
 ## Nested Formatting
 
-This paragraph has **bold text with *italic inside* it** and *italic with **bold inside** it*.
+This paragraph has **bold text with _italic inside_ it** and _italic with **bold inside** it_.
 
 ## Combined Elements in One Line
 

--- a/docs/reference/typography.md
+++ b/docs/reference/typography.md
@@ -74,8 +74,6 @@ If they use a role or link that supports hover previews, they'll have a dotted l
 
 ### Internal Links
 
-Internal links:
-
 Have a solid underline if they don't have hover previews:
 
 Link to [](tables.md).

--- a/docs/reference/typography.md
+++ b/docs/reference/typography.md
@@ -1,5 +1,7 @@
 ---
 title: Typography
+abbreviations:
+  HOVER: Wow a hoverable abbreviation
 ---
 
 # Heading Level 1
@@ -62,40 +64,37 @@ The {smallcaps}`HTML` specification defines web standards.
 
 ### External Links
 
-Visit [MyST Markdown](https://mystmd.org) for documentation.
+External links open in a new tab and display a small icon to indicate they leave the current site.
 
-Check out [Jupyter](https://jupyter.org) for notebooks.
+See [MyST Markdown](https://mystmd.org) for documentation.
+
+If they use a role or link that supports hover previews, they'll have a dotted line:
+
+[](https://doi.org/10.25080/hwcj9957)
 
 ### Internal Links
 
-Link to [another section](#math) on this page.
+Internal links:
 
-### Reference-Style Links
+Have a solid underline if they don't have hover previews:
 
-This is a [reference link][ref1] and another [reference link][ref2].
+Link to [](tables.md).
 
-[ref1]: https://mystmd.org
-[ref2]: https://jupyter.org
+Have a dotted underline if they have hover previews (e.g. for a label reference):
 
-### Auto-Links
+Link to [](#math).
 
-<https://mystmd.org>
+### Hover-only links
 
-<user@example.com>
+Hover-only links are black with a dotted line, for example:
+
+The HOVER will be black.
 
 ## Buttons
 
 ### Basic Button
 
 {button}`Click Me! <https://mystmd.org>`
-
-### Button Link
-
-{button-link} https://mystmd.org
-:color: primary
-
-Visit MyST
-{button-link}
 
 (math)=
 ## Math

--- a/packages/myst-to-react/src/basic.tsx
+++ b/packages/myst-to-react/src/basic.tsx
@@ -359,7 +359,7 @@ const BASIC_RENDERERS: BasicNodeRenderers = {
   abbreviation({ node, className }) {
     return (
       <Tooltip title={node.title} className={classNames(className)}>
-        <abbr aria-label={node.title} className="border-b border-dotted cursor-help">
+        <abbr aria-label={node.title} className="hover-text">
           <MyST ast={node.children} />
         </abbr>
       </Tooltip>

--- a/packages/myst-to-react/src/links/github.tsx
+++ b/packages/myst-to-react/src/links/github.tsx
@@ -325,8 +325,9 @@ export function GithubLink({
         }
       }}
     >
-      <a href={url} className={classNames('italic', className)} target="_blank" rel="noreferrer">
+      <a href={url} className={classNames('hover-link', className)} target="_blank" rel="noreferrer">
         {children}
+        <ExternalLinkIcon className="external-link-icon" />
       </a>
     </HoverPopover>
   );

--- a/packages/myst-to-react/src/links/github.tsx
+++ b/packages/myst-to-react/src/links/github.tsx
@@ -325,7 +325,12 @@ export function GithubLink({
         }
       }}
     >
-      <a href={url} className={classNames('hover-link', className)} target="_blank" rel="noreferrer">
+      <a
+        href={url}
+        className={classNames('hover-link', className)}
+        target="_blank"
+        rel="noreferrer"
+      >
         {children}
         <ExternalLinkIcon className="external-link-icon" />
       </a>

--- a/packages/myst-to-react/src/links/github.tsx
+++ b/packages/myst-to-react/src/links/github.tsx
@@ -332,7 +332,6 @@ export function GithubLink({
         rel="noreferrer"
       >
         {children}
-        <ExternalLinkIcon className="external-link-icon" />
       </a>
     </HoverPopover>
   );

--- a/packages/myst-to-react/src/links/index.tsx
+++ b/packages/myst-to-react/src/links/index.tsx
@@ -46,7 +46,7 @@ function InternalLink({
   const skipPreview = !page || (!page.description && !page.thumbnail);
   if (!page || skipPreview) {
     return (
-      <Link to={withBaseurl(url, baseurl)} prefetch="intent" className={className}>
+      <Link to={withBaseurl(url, baseurl)} prefetch="intent" className={classNames('link', className)}>
         {children}
       </Link>
     );
@@ -63,7 +63,7 @@ function InternalLink({
         />
       }
     >
-      <Link to={withBaseurl(url, baseurl)} prefetch="intent" className={className}>
+      <Link to={withBaseurl(url, baseurl)} prefetch="intent" className={classNames('hover-link', className)}>
         {children}
       </Link>
     </HoverPopover>
@@ -132,9 +132,10 @@ export const SimpleLink: NodeRenderer<TransformedLink> = ({ node, className }) =
       target="_blank"
       rel="noreferrer"
       href={node.url}
-      className={classNames(node.class, className)}
+      className={classNames('link', node.class, className)}
     >
       <MyST ast={node.children} />
+      <ExternalLinkIcon className="external-link-icon" />
     </a>
   );
 };

--- a/packages/myst-to-react/src/links/index.tsx
+++ b/packages/myst-to-react/src/links/index.tsx
@@ -46,7 +46,11 @@ function InternalLink({
   const skipPreview = !page || (!page.description && !page.thumbnail);
   if (!page || skipPreview) {
     return (
-      <Link to={withBaseurl(url, baseurl)} prefetch="intent" className={classNames('link', className)}>
+      <Link
+        to={withBaseurl(url, baseurl)}
+        prefetch="intent"
+        className={classNames('link', className)}
+      >
         {children}
       </Link>
     );
@@ -63,7 +67,11 @@ function InternalLink({
         />
       }
     >
-      <Link to={withBaseurl(url, baseurl)} prefetch="intent" className={classNames('hover-link', className)}>
+      <Link
+        to={withBaseurl(url, baseurl)}
+        prefetch="intent"
+        className={classNames('hover-link', className)}
+      >
         {children}
       </Link>
     </HoverPopover>

--- a/packages/myst-to-react/src/links/ror.tsx
+++ b/packages/myst-to-react/src/links/ror.tsx
@@ -1,5 +1,4 @@
 import { default as useSWR } from 'swr';
-import { ArrowTopRightOnSquareIcon as ExternalLinkIcon } from '@heroicons/react/24/outline';
 import { HoverPopover } from '../components/index.js';
 import { MyST } from '../MyST.js';
 import type { GenericNode } from 'myst-common';
@@ -102,7 +101,6 @@ export function RORLink({
         className={classNames('hover-link', className)}
       >
         <MyST ast={node.children} />
-        <ExternalLinkIcon className="external-link-icon" />
       </a>
     </HoverPopover>
   );

--- a/packages/myst-to-react/src/links/ror.tsx
+++ b/packages/myst-to-react/src/links/ror.tsx
@@ -1,8 +1,10 @@
 import { default as useSWR } from 'swr';
+import { ArrowTopRightOnSquareIcon as ExternalLinkIcon } from '@heroicons/react/24/outline';
 import { HoverPopover } from '../components/index.js';
 import { MyST } from '../MyST.js';
 import type { GenericNode } from 'myst-common';
 import { RorIcon } from '@scienceicons/react/24/solid';
+import classNames from 'classnames';
 
 const fetcher = (...args: Parameters<typeof fetch>) =>
   fetch(...args).then((res) => {
@@ -97,9 +99,10 @@ export function RORLink({
         href={`https://ror.org/${ror}`}
         target="_blank"
         rel="noopener noreferrer"
-        className={className}
+        className={classNames('hover-link', className)}
       >
         <MyST ast={node.children} />
+        <ExternalLinkIcon className="external-link-icon" />
       </a>
     </HoverPopover>
   );

--- a/packages/myst-to-react/src/links/rrid.tsx
+++ b/packages/myst-to-react/src/links/rrid.tsx
@@ -1,5 +1,7 @@
 import { default as useSWR } from 'swr';
+import { ArrowTopRightOnSquareIcon as ExternalLinkIcon } from '@heroicons/react/24/outline';
 import { HoverPopover } from '../components/index.js';
+import classNames from 'classnames';
 
 const fetcher = (...args: Parameters<typeof fetch>) =>
   fetch(...args).then((res) => {
@@ -75,9 +77,10 @@ export function RRIDLink({ rrid, className }: { rrid: string; className?: string
         href={`https://scicrunch.org/resolver/${rrid}`}
         target="_blank"
         rel="noopener noreferrer"
-        className={className}
+        className={classNames('hover-link', className)}
       >
         RRID: <cite className="italic">{rrid}</cite>
+        <ExternalLinkIcon className="external-link-icon" />
       </a>
     </HoverPopover>
   );

--- a/packages/myst-to-react/src/links/rrid.tsx
+++ b/packages/myst-to-react/src/links/rrid.tsx
@@ -1,5 +1,4 @@
 import { default as useSWR } from 'swr';
-import { ArrowTopRightOnSquareIcon as ExternalLinkIcon } from '@heroicons/react/24/outline';
 import { HoverPopover } from '../components/index.js';
 import classNames from 'classnames';
 
@@ -80,7 +79,6 @@ export function RRIDLink({ rrid, className }: { rrid: string; className?: string
         className={classNames('hover-link', className)}
       >
         RRID: <cite className="italic">{rrid}</cite>
-        <ExternalLinkIcon className="external-link-icon" />
       </a>
     </HoverPopover>
   );

--- a/packages/myst-to-react/src/links/wiki.tsx
+++ b/packages/myst-to-react/src/links/wiki.tsx
@@ -118,8 +118,9 @@ export function WikiLink({
 }) {
   return (
     <HoverPopover card={({ load }) => <WikiChild wiki={wiki} page={page} load={load} />}>
-      <a href={url} className={classNames('italic', className)} target="_blank" rel="noreferrer">
+      <a href={url} className={classNames('hover-link', className)} target="_blank" rel="noreferrer">
         {children}
+        <ExternalLinkIcon className="external-link-icon" />
       </a>
     </HoverPopover>
   );

--- a/packages/myst-to-react/src/links/wiki.tsx
+++ b/packages/myst-to-react/src/links/wiki.tsx
@@ -118,7 +118,12 @@ export function WikiLink({
 }) {
   return (
     <HoverPopover card={({ load }) => <WikiChild wiki={wiki} page={page} load={load} />}>
-      <a href={url} className={classNames('hover-link', className)} target="_blank" rel="noreferrer">
+      <a
+        href={url}
+        className={classNames('hover-link', className)}
+        target="_blank"
+        rel="noreferrer"
+      >
         {children}
         <ExternalLinkIcon className="external-link-icon" />
       </a>

--- a/packages/myst-to-react/src/links/wiki.tsx
+++ b/packages/myst-to-react/src/links/wiki.tsx
@@ -1,5 +1,5 @@
 import { default as useSWR } from 'swr';
-import { ArrowTopRightOnSquareIcon as ExternalLinkIcon } from '@heroicons/react/24/outline';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import { HoverPopover, LinkCard } from '../components/index.js';
 import React from 'react';
 import classNames from 'classnames';
@@ -85,7 +85,7 @@ function WikiChild({ page, wiki, load }: { page: string; wiki: string; load: boo
           target="_blank"
           rel="noreferrer"
         >
-          <ExternalLinkIcon width="1rem" height="1rem" className="float-right" />
+          <ArrowTopRightOnSquareIcon width="1rem" height="1rem" className="float-right" />
           <WikiTextMark />
         </a>
         <div className="mt-2">Error loading "{page}" from wikipedia.</div>
@@ -125,7 +125,6 @@ export function WikiLink({
         rel="noreferrer"
       >
         {children}
-        <ExternalLinkIcon className="external-link-icon" />
       </a>
     </HoverPopover>
   );

--- a/styles/button.css
+++ b/styles/button.css
@@ -1,10 +1,17 @@
-a.button,
-button.button,
-span.button,
-cite.button a {
-  @apply px-4 py-2 font-bold rounded no-underline cursor-pointer;
-  @apply text-white bg-blue-500 whitespace-nowrap;
-  &:hover {
-    @apply bg-blue-700;
+@layer components {
+  a.button,
+  button.button,
+  span.button,
+  cite.button a {
+    @apply px-4 py-2 font-bold rounded no-underline cursor-pointer;
+    @apply text-white dark:text-white hover:text-white dark:hover:text-white;
+    @apply bg-blue-500 whitespace-nowrap;
+    &:hover {
+      @apply bg-blue-700;
+    }
+    /* Hide external link icon on buttons */
+    .external-link-icon {
+      @apply hidden;
+    }
   }
 }

--- a/styles/button.css
+++ b/styles/button.css
@@ -1,3 +1,4 @@
+/* TODO: Separate out theme styling from component styling more effectively https://github.com/jupyter-book/myst-theme/issues/763 */
 @layer components {
   a.button,
   button.button,

--- a/styles/hover.css
+++ b/styles/hover.css
@@ -41,5 +41,5 @@
 
 /* Non-link hover elements (e.g., abbreviations): gray dotted underline */
 .hover-text {
-  @apply underline decoration-dotted decoration-[0.15em] underline-offset-[0.15em] decoration-gray-500 dark:decoration-gray-400 cursor-help;
+  @apply underline decoration-dotted decoration-[0.1em] underline-offset-[0.15em] decoration-gray-500 dark:decoration-gray-400 cursor-help;
 }

--- a/styles/hover.css
+++ b/styles/hover.css
@@ -36,6 +36,10 @@
   @apply text-sm bg-white border rounded shadow-xl dark:bg-slate-800 border-gray-50;
 }
 
-.hover-link {
-  @apply font-normal text-blue-700 underline-offset-2 decoration-slate-200 dark:decoration-slate-600 dark:text-blue-100 hover:text-blue-500;
+/* Hoverable links: dashed underline */
+.hover-link { @apply decoration-dashed; }
+
+/* Non-link hover elements (e.g., abbreviations): gray dashed underline */
+.hover-text {
+  @apply underline decoration-dashed decoration-[1.5px] underline-offset-2 decoration-gray-400 dark:decoration-gray-500 cursor-help;
 }

--- a/styles/hover.css
+++ b/styles/hover.css
@@ -36,10 +36,10 @@
   @apply text-sm bg-white border rounded shadow-xl dark:bg-slate-800 border-gray-50;
 }
 
-/* Hoverable links: dashed underline */
-.hover-link { @apply decoration-dashed; }
+/* Hoverable links: dotted underline */
+.hover-link { @apply decoration-dotted; }
 
-/* Non-link hover elements (e.g., abbreviations): gray dashed underline */
+/* Non-link hover elements (e.g., abbreviations): gray dotted underline */
 .hover-text {
-  @apply underline decoration-dashed decoration-[1.5px] underline-offset-2 decoration-gray-400 dark:decoration-gray-500 cursor-help;
+  @apply underline decoration-dotted decoration-[0.15em] underline-offset-[0.15em] decoration-gray-500 dark:decoration-gray-400 cursor-help;
 }

--- a/styles/hover.css
+++ b/styles/hover.css
@@ -1,45 +1,49 @@
-.hover-card-content {
-  animation-duration: 0.6s;
-  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-  z-index: 10;
-}
-.hover-card-content[data-side='top'] {
-  animation-name: slideUp;
-}
-.hover-card-content[data-side='bottom'] {
-  animation-name: slideDown;
-}
-
-@keyframes slideUp {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
+@layer components {
+  .hover-card-content {
+    animation-duration: 0.6s;
+    animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+    z-index: 10;
   }
-  to {
-    opacity: 1;
-    transform: translateY(0);
+  .hover-card-content[data-side='top'] {
+    animation-name: slideUp;
   }
-}
-
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-10px);
+  .hover-card-content[data-side='bottom'] {
+    animation-name: slideDown;
   }
-  to {
-    opacity: 1;
-    transform: translateY(0);
+
+  @keyframes slideUp {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
-}
 
-.hover-document {
-  @apply text-sm bg-white border rounded shadow-xl dark:bg-slate-800 border-gray-50;
-}
+  @keyframes slideDown {
+    from {
+      opacity: 0;
+      transform: translateY(-10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 
-/* Hoverable links: dotted underline */
-.hover-link { @apply decoration-dotted; }
+  .hover-document {
+    @apply text-sm bg-white border rounded shadow-xl dark:bg-slate-800 border-gray-50;
+  }
 
-/* Non-link hover elements (e.g., abbreviations): gray dotted underline */
-.hover-text {
-  @apply underline decoration-dotted decoration-[0.1em] underline-offset-[0.15em] decoration-gray-500 dark:decoration-gray-400 cursor-help;
+  /* Hoverable links: dotted underline */
+  .hover-link {
+    @apply decoration-dotted;
+  }
+
+  /* Non-link hover elements (e.g., abbreviations): gray dotted underline */
+  .hover-text {
+    @apply underline decoration-dotted decoration-[0.1em] underline-offset-[0.15em] decoration-gray-500 dark:decoration-gray-400 cursor-help;
+  }
 }

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -7,9 +7,9 @@
     font-variant: small-caps;
   }
 
-  /* Links: blue with 1.5px underline */
+  /* Links: blue with underline */
   .link, .hover-link {
-    @apply text-blue-700 dark:text-blue-400 underline decoration-[1.5px] underline-offset-2 decoration-blue-700/70 dark:decoration-blue-400/70 hover:text-blue-500 dark:hover:text-blue-300 hover:decoration-blue-500 dark:hover:decoration-blue-300;
+    @apply text-blue-700 dark:text-blue-400 underline decoration-[0.15em] underline-offset-[0.15em] decoration-blue-400 dark:decoration-blue-500 hover:text-blue-500 dark:hover:text-blue-300 hover:decoration-blue-500 dark:hover:decoration-blue-300;
   }
 
   /* External link icon (styles the ArrowTopRightOnSquareIcon component) */

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -6,6 +6,16 @@
   .smallcaps {
     font-variant: small-caps;
   }
+
+  /* Links: blue with 1.5px underline */
+  .link, .hover-link {
+    @apply text-blue-700 dark:text-blue-400 underline decoration-[1.5px] underline-offset-2 decoration-blue-700/70 dark:decoration-blue-400/70 hover:text-blue-500 dark:hover:text-blue-300 hover:decoration-blue-500 dark:hover:decoration-blue-300;
+  }
+
+  /* External link icon (styles the ArrowTopRightOnSquareIcon component) */
+  .external-link-icon {
+    @apply inline-block w-[0.85em] h-[0.85em] ml-0.5 align-baseline opacity-80;
+  }
 }
 
 @layer base {

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -9,7 +9,7 @@
 
   /* Links: blue with underline */
   .link, .hover-link {
-    @apply text-blue-700 dark:text-blue-400 underline decoration-[0.15em] underline-offset-[0.15em] decoration-blue-400 dark:decoration-blue-500 hover:text-blue-500 dark:hover:text-blue-300 hover:decoration-blue-500 dark:hover:decoration-blue-300;
+    @apply text-blue-700 dark:text-blue-400 underline decoration-[0.1em] underline-offset-[0.15em] decoration-blue-400 dark:decoration-blue-500 hover:text-blue-500 dark:hover:text-blue-300 hover:decoration-blue-500 dark:hover:decoration-blue-300;
   }
 
   /* External link icon (styles the ArrowTopRightOnSquareIcon component) */

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -6,9 +6,12 @@
   .smallcaps {
     font-variant: small-caps;
   }
+}
 
+@layer components {
   /* Links: blue with underline */
-  .link, .hover-link {
+  .link,
+  .hover-link {
     @apply text-blue-700 dark:text-blue-400 underline decoration-[0.1em] underline-offset-[0.15em] decoration-blue-400 dark:decoration-blue-500 hover:text-blue-500 dark:hover:text-blue-300 hover:decoration-blue-500 dark:hover:decoration-blue-300;
   }
 

--- a/themes/book/app/root.tsx
+++ b/themes/book/app/root.tsx
@@ -84,7 +84,7 @@ function createSearch(index: MystSearchIndex): ISearch {
 }
 
 /*
- * Component that shows a "no CSS loaded" warning when a page 
+ * Component that shows a "no CSS loaded" warning when a page
  * loads without the built-in MyST stylesheet. This can happen on static builds
  * when the BASE_URL doesn't match the deployment base URL.
  */


### PR DESCRIPTION
This standardizes our link styles so that they behave consistently. See the issue below for some discussion and the proposal this implements:

- https://github.com/jupyter-book/myst-theme/issues/689

Major changes:

- All links are underlined and blue
- External links have a little "external" button to the right
- Hoverable links have a _dashed_ underline
- Non-link hoverables (terms) have a _dashed_ underline and black

Also cleaned up the local install instructions along the way

👉 [Preview here](https://deploy-preview-757--myst-theme.netlify.app/reference/typography/#links)

Example of how this looks in netlify:


![CleanShot 2026-01-18 at 13 31 15](https://github.com/user-attachments/assets/22bed460-c15b-4cb8-815b-b106bbe66adc)

---

- closes https://github.com/jupyter-book/mystmd/issues/59
- closes https://github.com/jupyter-book/myst-theme/issues/689