### PR TITLE
Update inline image rules

### DIFF
--- a/.changeset/fix-inline-images-regression.md
+++ b/.changeset/fix-inline-images-regression.md
@@ -1,0 +1,5 @@
+---
+"@myst-theme/styles": patch
+---
+
+Fix inline image styling that was incorrectly applied to images in figures and tables

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -39,9 +39,22 @@ Inline: [![MyST Logo](../_static/myst-logo-light.svg)](https://google.com)
 
 ## Inline in tables
 
+:::{note}
+Images in tables are currently rendered at full size, even when inline with text.
+See [#761](https://github.com/jupyter-book/myst-theme/issues/761) for tracking.
+:::
+
 | Description | Inline image |
 | ----------- | ------------ |
 | Text before ![MyST Logo](../_static/myst-logo-light.svg) text after | Works inside table cells too |
+
+## Standalone images in tables
+
+Images alone in table cells (like contributor cards) should display at their natural size:
+
+| Logo 1 | Logo 2 | Logo 3 |
+| :----: | :----: | :----: |
+| ![MyST](../_static/myst-logo-light.svg) | ![MyST](../_static/myst-logo-dark.svg) | ![MyST](../_static/myst-logo-light.svg) |
 
 ## Inline in definition lists
 

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -35,13 +35,15 @@
   .prose dd {
     @apply ml-8;
   }
-  /* Keep inline images inside text flow from forcing line breaks */
-  .article p img,
-  .article table img,
-  .article dd img,
-  .prose p img,
-  .prose table img,
-  .prose dd img {
+  /* Inline images (direct children of paragraphs, with or without links) */
+  .article p > img,
+  .article p > a > img,
+  .article dd > img,
+  .article dd > a > img,
+  .prose p > img,
+  .prose p > a > img,
+  .prose dd > img,
+  .prose dd > a > img {
     margin: 0;
     display: inline-block;
     max-height: 1.2em;


### PR DESCRIPTION
This fixes a regression where the inline image styling (from #710) was incorrectly applied to images inside figures and tables, shrinking them to text-line height (the tables was intentional, but we decided it's not the desired behavior).

This PR uses direct child selectors (`p > img` instead of `p img`) to only target images that are direct children of paragraphs. This _excludes_ (so they are normal sized images):

- Images in figures (inside `<figure>` elements)
- Standalone images (Aren't wrapped in `<p>`)
- Table images (inside `<td>`, not `<p>`)

We're _introducing_ sub-optimal behavior here as well, which I've added in the docs and am now tracking here because we decided this is a better trade-off:

- #761

---

- closes #760

