### PR TITLE
Remove docs changeset to fix error

### DIFF
--- a/.changeset/strong-spiders-beam.md
+++ b/.changeset/strong-spiders-beam.md
@@ -2,7 +2,6 @@
 "myst-to-react": patch
 "@myst-theme/book": patch
 "@myst-theme/styles": patch
-"@myst-theme/docs": patch
 ---
 
 Standardize link styles


### PR DESCRIPTION
A recent PR added `docs/` in the changesets file and apparently this breaks changesets so this removes it