### PR TITLE
Update and fix icon link class

### DIFF
--- a/packages/myst-to-react/src/links/index.tsx
+++ b/packages/myst-to-react/src/links/index.tsx
@@ -148,8 +148,8 @@ export const SimpleLink: NodeRenderer<TransformedLink> = ({ node, className }) =
       className={classNames('link', node.class, className)}
     >
       <MyST ast={node.children} />
-      {isStatic && <ArrowDownTrayIcon className="link-with-icon" />}
-      {!isStatic && <ExternalLinkIcon className="link-with-icon" />}
+      {isStatic && <ArrowDownTrayIcon className="link-icon" />}
+      {!isStatic && <ExternalLinkIcon className="link-icon" />}
     </a>
   );
 };

--- a/styles/button.css
+++ b/styles/button.css
@@ -11,7 +11,7 @@
       @apply bg-blue-700;
     }
     /* Hide external link icon on buttons */
-    &.link-with-icon {
+    & .link-icon {
       @apply hidden;
     }
   }

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -16,7 +16,7 @@
   }
 
   /* Styles the icon that comes with External and Download links */
-  .link-with-icon {
+  .link-icon {
     @apply inline-block w-[0.85em] h-[0.85em] ml-0.5 align-baseline opacity-80;
   }
 }


### PR DESCRIPTION
We missed a space in the last merge which means the button link icon rule isn't properly over-ridden. This adds it back and fixes the classname so it's more correct

[Demo](https://deploy-preview-773--myst-theme.netlify.app/reference/typography/#buttons)

<img width="316" height="204" alt="CleanShot 2026-01-22 at 22 19 25@2x" src="https://github.com/user-attachments/assets/e04c7788-29bc-4060-a349-a7e51428a2f7" />

