### PR TITLE
Make contents tab have a background to hide margin content

### DIFF
--- a/packages/site/src/components/DocumentOutline.tsx
+++ b/packages/site/src/components/DocumentOutline.tsx
@@ -401,6 +401,7 @@ export const DocumentOutline = ({
         className={classNames(
           'myst-outline not-prose overflow-y-auto',
           'transition-opacity duration-700', // Animation on load
+          'bg-white/95 dark:bg-stone-900/95 backdrop-blur-sm rounded-lg p-2 -m-2', // Solid background to avoid overlap with margin content
           className,
         )}
         style={{


### PR DESCRIPTION
This adds a background to the TOC so that it hides margin content if they're both present and open at the same time.

### Example: `main`

<img width="2818" height="1648" alt="Image" src="https://github.com/user-attachments/assets/b4d6c989-e961-463a-b63a-2d1fd1a6a737" />

### Example: this PR

<img width="1228" height="1634" alt="CleanShot 2026-01-23 at 09 36 55@2x" src="https://github.com/user-attachments/assets/00122636-522e-4cc3-af53-aaf28d69a121" />


---
- closes https://github.com/jupyter-book/myst-theme/issues/774