### PR TITLE
🔌 sidebar mount point POC

### DIFF
--- a/.changeset/sharp-papers-kneel.md
+++ b/.changeset/sharp-papers-kneel.md
@@ -1,0 +1,7 @@
+---
+'@myst-theme/common': patch
+'@myst-theme/site': patch
+'@myst-theme/book': patch
+---
+
+A sidebar mount point for JS based modifications based on a theme template

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -84,6 +84,7 @@ export type CommonTemplateOptions = {
   numbered_references?: boolean;
   folders?: boolean;
   style?: string;
+  sidebar_mount_js?: string;
   hide_authors?: boolean;
   hide_footer_links?: boolean;
   hide_toc?: boolean;

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -166,6 +166,8 @@ export function updateSiteManifestStaticLinksInplace(
   if (data.options.logo_dark) data.options.logo_dark = updateUrl(data.options.logo_dark);
   if (data.options.favicon) data.options.favicon = updateUrl(data.options.favicon);
   if (data.options.style) data.options.style = updateUrl(data.options.style);
+  if (data.options.sidebar_mount_js)
+    data.options.sidebar_mount_js = updateUrl(data.options.sidebar_mount_js);
   if (data.parts) {
     Object.values(data.parts).forEach(({ mdast }) => {
       updateMdastStaticLinksInplace(mdast, updateUrl);

--- a/packages/site/src/components/Navigation/PrimarySidebar.tsx
+++ b/packages/site/src/components/Navigation/PrimarySidebar.tsx
@@ -14,6 +14,7 @@ import {
 import type { Heading } from '@myst-theme/common';
 import { Toc } from './TableOfContentsItems.js';
 import { ExternalOrInternalLink } from './Link.js';
+import { SidebarWidget } from './SidebarWidget.js';
 import type { SiteManifest, SiteNavItem } from 'myst-config';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { ChevronRightIcon } from '@heroicons/react/24/solid';
@@ -149,6 +150,7 @@ export const PrimarySidebar = ({
   const top = useThemeTop();
   const { bannerState } = useBannerState();
   const grid = useGridSystemProvider();
+  const baseurl = useBaseurl();
   const footerRef = useRef<HTMLDivElement>(null);
   const [open] = useNavOpen();
   const config = useSiteManifest();
@@ -191,6 +193,9 @@ export const PrimarySidebar = ({
         )}
       >
         <div className="myst-primary-sidebar-nav flex-grow py-6 overflow-y-auto primary-scrollbar">
+          {config.options?.sidebar_mount_js && (
+            <SidebarWidget scriptUrl={config.options.sidebar_mount_js} baseurl={baseurl} />
+          )}
           {nav && (
             <nav
               aria-label="Navigation"

--- a/packages/site/src/components/Navigation/SidebarWidget.tsx
+++ b/packages/site/src/components/Navigation/SidebarWidget.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useRef } from 'react';
+
+/**
+ * Renders a container div and loads the sidebar_mount_js ESM. When loaded,
+ * calls renderSidebar(container) so the script can use plain DOM APIs on the
+ * container. The script URL is rewritten by the theme (content server or
+ * /myst_assets_folder/ in static).
+ */
+export function SidebarWidget({
+  scriptUrl,
+  baseurl = '',
+}: {
+  scriptUrl: string;
+  baseurl?: string;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !scriptUrl) return;
+
+    const fullUrl = scriptUrl.startsWith('http') ? scriptUrl : (baseurl || '') + scriptUrl;
+
+    import(/* @vite-ignore */ fullUrl)
+      .then((module) => {
+        if (typeof module.renderSidebar === 'function') {
+          module.renderSidebar(container);
+        }
+      })
+      .catch(() => {
+        // Script failed to load or has no renderSidebar export
+      });
+  }, [scriptUrl, baseurl]);
+
+  return <div ref={containerRef} className="myst-sidebar-widget" />;
+}

--- a/themes/book/template.yml
+++ b/themes/book/template.yml
@@ -70,6 +70,9 @@ options:
   - type: file
     id: style
     description: Local path to a CSS file
+  - type: file
+    id: sidebar_mount_js
+    description: Local path to a Javascript file to render within the sidebar mount area
 parts:
   - id: footer
     description: The site wide footer


### PR DESCRIPTION
This PR shows a way for a theme to provide artibrary but contained JS mount points outside of the main MyST content flow that can be configured at build time.


for example, saving this ESM module content to a file `sidebar.mjs` in the myst folder.

```yaml
# sidebar.mjs

/**
 * Sidebar widget ESM. The theme loads this and calls renderSidebar(container)
 * with the container DOM element. Use plain DOM APIs on container.
 */
export function renderSidebar(container) {
  const div = document.createElement('div');
  div.textContent = 'I <3 Javascript';
  div.setAttribute('style', [
    'margin: 0.5em 0;',
    'font-size: 1.25rem;',
    'font-weight: bold;',
    'color: #ff00ff;',
    'font-family: Comic Sans MS, cursive;',
    'border: 1px dashed #ff00ff;',
    'padding: 0.5em;',
    'border-radius: 0.5em;',
    'text-align: center;',
  ].join(' '));
  container.appendChild(div);
}
```

Then add this in your `myst.yml`

```yaml
# myst.yml#site.sidebar_mount_js

site:
  options:
    logo_text: Plots
    style: ./style.css
    sidebar_mount_js: ./sidebar.mjs
```


