### PR TITLE
More aggressively hide external link icon

### DIFF
--- a/styles/button.css
+++ b/styles/button.css
@@ -10,9 +10,5 @@
     &:hover {
       @apply bg-blue-700;
     }
-    /* Hide external link icon on buttons */
-    & .link-icon {
-      @apply hidden;
-    }
   }
 }

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -15,8 +15,15 @@
     @apply text-blue-700 dark:text-blue-400 underline decoration-[0.1em] underline-offset-[0.15em] decoration-blue-400 dark:decoration-blue-500 hover:text-blue-500 dark:hover:text-blue-300 hover:decoration-blue-500 dark:hover:decoration-blue-300;
   }
 
-  /* Styles the icon that comes with External and Download links */
+  /* External/download link icons: hidden by default, shown only for plain text links in prose */
   .link-icon {
+    @apply hidden;
+  }
+
+  /* Only show link icons when it's a "prose" style element.
+   * This rule tries to filter out anything that's not just "link with some text inside, in page content".
+   */
+  .prose a:not(.button):not(:has(img, figure, picture, video)) > .link-icon {
     @apply inline-block w-[0.85em] h-[0.85em] ml-0.5 align-baseline opacity-80;
   }
 }


### PR DESCRIPTION
This flips the logic of our icon-links (for external links and downloads): instead of adding new rules to hide it, we hide it by default and have a single rule that says "only under these conditions should you _show_ it". Let's see if this makes for more consistent behavior.

### Visual testing

- ✅ Images no longer have external link icons: https://deploy-preview-786--myst-theme.netlify.app/reference/images/
- ✅ Links only have them if they should: https://deploy-preview-786--myst-theme.netlify.app/reference/typography/#links-and-terms
- ✅ Buttons do not have them: https://deploy-preview-786--myst-theme.netlify.app/reference/typography/#buttons

IMO this is a better fix!