### PR TITLE
Only create new intersectionobserver arrays if we've changed

### DIFF
--- a/packages/site/src/components/DocumentOutline.tsx
+++ b/packages/site/src/components/DocumentOutline.tsx
@@ -26,6 +26,7 @@ const onClient = typeof document !== 'undefined';
  * loops with IntersectionObserver and MutationObserver.
  */
 function arrayIfChanged<T>(prev: T[], next: T[]): T[] {
+  if (prev === next) return prev;
   if (prev.length !== next.length) return next;
   for (let i = 0; i < prev.length; i++) {
     if (prev[i] !== next[i]) return next;


### PR DESCRIPTION
I think I've figured out the bug behind #789 . For each intersection observer callback, we were creating a _new_ array of elements on screen, even if the elements on the screen hadn't actually changed. Creating a new array seemed to be re-triggering the same callback (since there were new elements to observe). This PR only returns a _new_ array if the list has actually changed.

I found this hard to test, so I recorded two gifs before and after this on a page that demonstrated the same content.

### Before this PR

Note these are docs I just auto-generated to test out this bug, I'm not adding them in the PR!

(it was a little hard to capture because of framerate issues, but I assure you it was flashing!)

![CleanShot 2026-02-03 at 16 20 53](https://github.com/user-attachments/assets/3af6b9a9-e9a9-4eff-91ae-b7aba15f90d8)


### After this PR

I tried to move around the screen to see if we ever got flashing and we did not

![CleanShot 2026-02-03 at 16 22 46](https://github.com/user-attachments/assets/6d43de09-835a-4211-8914-805bf7d1efd0)


---

- closes This section has more margin content to continue testing as you scroll.
