### PR TITLE
Fix widebar width on mobile

### DIFF
--- a/packages/site/src/components/Navigation/PrimarySidebar.tsx
+++ b/packages/site/src/components/Navigation/PrimarySidebar.tsx
@@ -169,7 +169,7 @@ export const PrimarySidebar = ({
         'myst-primary-sidebar',
         'fixed',
         `xl:${grid}`, // for example, xl:article-grid
-        'grid-gap xl:w-screen xl:pointer-events-none overflow-auto max-xl:w-[350px]',
+        'grid-gap xl:w-screen xl:pointer-events-none overflow-auto max-xl:w-[75vw] max-xl:max-w-[350px]',
         { 'lg:hidden': nav && hide_toc },
         { hidden: !open, 'z-30': open, 'z-10': !open },
       )}


### PR DESCRIPTION
This updates our sidebar width to be fixed width instead of minimum width. I _think_ this only affects mobile. Its goal is to prevent the sidebar growing and shrinking as you open dropdown trees in the TOC.

#### Before this PR

![CleanShot 2026-02-04 at 13 19 37](https://github.com/user-attachments/assets/f5c3989c-7658-4d23-8602-c0ce2c67a69f)


### After this PR

![CleanShot 2026-02-04 at 13 20 16](https://github.com/user-attachments/assets/0f6ea530-9da6-4323-a960-7f37f95451f8)




---

- closes #791 