### PR TITLE
↔️↕️ Add both vert and horiz gap for badges

### DIFF
--- a/.changeset/lucky-elephants-ring.md
+++ b/.changeset/lucky-elephants-ring.md
@@ -1,0 +1,5 @@
+---
+"myst-to-react": patch
+---
+
+Add both vert and horiz gap for badges

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -8,6 +8,10 @@ project:
   # keywords: []
   # authors: []
   github: https://github.com/jupyter-book/myst-theme
+  error_rules:
+    - rule: link-resolves
+      keys:
+        - 'https://github.com/**'
   jupyter: true
   parts:
     banner: |

--- a/docs/reference/github-previews.md
+++ b/docs/reference/github-previews.md
@@ -2,6 +2,8 @@
 
 Hover each link below to preview the GitHub hover card and verify the state icon and color.
 
+## Issue statuses
+
 | State | Example |
 | --- | --- |
 | Open issue | https://github.com/jupyter-book/test-repo/issues/1 |
@@ -10,3 +12,7 @@ Hover each link below to preview the GitHub hover card and verify the state icon
 | Open PR | https://github.com/jupyter-book/test-repo/pull/4 |
 | Merged PR | https://github.com/jupyter-book/test-repo/pull/5 |
 | Closed PR (not merged) | https://github.com/jupyter-book/test-repo/pull/6 |
+
+## Many badges
+
+This issue has many badges: https://github.com/cncf/toc/issues/1538

--- a/packages/myst-to-react/src/links/github.tsx
+++ b/packages/myst-to-react/src/links/github.tsx
@@ -247,12 +247,12 @@ function GithubIssuePreview({
       </div>
       <p className="text-md max-h-[4rem] overflow-hidden">{issueData.body}</p>
       {issueData.labels?.length > 0 && (
-        <div className="flex flex-wrap">
+        <div className="flex flex-wrap gap-1">
           {issueData.labels?.map((label: any) => (
             <span
               key={label.id}
               className={classNames(
-                'mr-1 text-xs inline-flex items-center px-2 py-0.5 rounded-full',
+                'text-xs inline-flex items-center px-2 py-0.5 rounded-full',
                 {
                   'text-white': useWhiteTextColor(label.color),
                 },

--- a/packages/myst-to-react/src/links/github.tsx
+++ b/packages/myst-to-react/src/links/github.tsx
@@ -251,12 +251,9 @@ function GithubIssuePreview({
           {issueData.labels?.map((label: any) => (
             <span
               key={label.id}
-              className={classNames(
-                'text-xs inline-flex items-center px-2 py-0.5 rounded-full',
-                {
-                  'text-white': useWhiteTextColor(label.color),
-                },
-              )}
+              className={classNames('text-xs inline-flex items-center px-2 py-0.5 rounded-full', {
+                'text-white': useWhiteTextColor(label.color),
+              })}
               style={{ backgroundColor: `#${label.color}` }}
             >
               {label.name}


### PR DESCRIPTION
We were adding horizontal padding to issue labels with `mr-1`, but didn't have vertical padding. This switches the whole section to `gap-1` which I think will make it work on both horizontal and vertical.

We have been hitting linkcheck rate limits for GitHub, so this also adds github to our list of "ignore linkcheck errors" to see if that skips the check and helps out. I think that helps

Preview (Without this PR, there's no vertical gap at all b/w the labels)

<img width="2500" height="1374" alt="CleanShot 2026-03-09 at 13 30 12@2x" src="https://github.com/user-attachments/assets/5c34360c-b55a-4ac1-a837-6ecd24dc70fc" />


---

- closes #834 