### PR TITLE
Render `grid-item`, taking `columns` into consideration

### DIFF
--- a/.changeset/cute-hounds-drum.md
+++ b/.changeset/cute-hounds-drum.md
@@ -1,0 +1,6 @@
+---
+'myst-to-react': minor
+'@myst-theme/styles': minor
+---
+
+Add grid-item renderer

--- a/.changeset/cute-hounds-drum.md
+++ b/.changeset/cute-hounds-drum.md
@@ -1,5 +1,6 @@
 ---
 'myst-to-react': minor
+'myst-demo': minor
 '@myst-theme/styles': minor
 ---
 

--- a/.changeset/lucky-elephants-ring.md
+++ b/.changeset/lucky-elephants-ring.md
@@ -1,5 +1,5 @@
 ---
-"myst-to-react": patch
+'myst-to-react': patch
 ---
 
 Add both vert and horiz gap for badges

--- a/docs/reference/structure.md
+++ b/docs/reference/structure.md
@@ -45,27 +45,8 @@ Content in the right column with separate structure.
 
 :::{grid-item}
 :columns: 4
+```{note}
 On the left!
-:::
-:::{grid-item}
-:columns: 8
-On the right!
-:::
-::::
-::::{grid} 1 1 12 12
-
-Flipped left/right widths:
-
-:::{grid-item}
-:columns: 8
-On the left!
-:::
-:::{grid-item}
-:columns: 4
-On the right!
-:::
-::::
-
 ## Margins and Sidebars
 
 ### Margins

--- a/docs/reference/structure.md
+++ b/docs/reference/structure.md
@@ -41,7 +41,7 @@ Content in the right column with separate structure.
 ::::
 
 ### Uneven columns
-::::{grid}
+::::{grid} 1 1 12 12
 
 :::{grid-item}
 :columns: 4

--- a/docs/reference/structure.md
+++ b/docs/reference/structure.md
@@ -52,7 +52,7 @@ On the left!
 On the right!
 :::
 ::::
-::::{grid}
+::::{grid} 1 1 12 12
 
 Flipped left/right widths:
 

--- a/docs/reference/structure.md
+++ b/docs/reference/structure.md
@@ -41,12 +41,33 @@ Content in the right column with separate structure.
 ::::
 
 ### Uneven columns
-::::{grid} 1 1 12 12
+:::::{grid} 1 1 12 12
 
-:::{grid-item}
+::::{grid-item}
 :columns: 4
-```{note}
+:::{note}
 On the left!
+:::
+::::
+::::{grid-item}
+:columns: 8
+:::{note}
+On the right!
+:::
+::::
+::::{grid-item}
+:columns: 8
+:::{note}
+On the left!
+:::
+::::
+::::{grid-item}
+:columns: 4
+:::{note}
+On the right!
+:::
+::::
+:::::
 ## Margins and Sidebars
 
 ### Margins

--- a/docs/reference/structure.md
+++ b/docs/reference/structure.md
@@ -14,12 +14,14 @@ This content is centered using a div with text-center class.
 :::
 
 
-## Multiple Columns
+## Grids and Columns
+
+### Basic grid
 
 ::::{grid} 2
 
 :::{grid-item}
-### Left Column
+#### Left Column
 
 Content in the left column with its own heading and structure.
 
@@ -28,7 +30,7 @@ Content in the left column with its own heading and structure.
 :::
 
 :::{grid-item}
-### Right Column
+#### Right Column
 
 Content in the right column with separate structure.
 
@@ -36,6 +38,32 @@ Content in the right column with separate structure.
 - Point B
 :::
 
+::::
+
+### Uneven columns
+::::{grid}
+
+:::{grid-item}
+:columns: 4
+On the left!
+:::
+:::{grid-item}
+:columns: 8
+On the right!
+:::
+::::
+::::{grid}
+
+Flipped left/right widths:
+
+:::{grid-item}
+:columns: 8
+On the left!
+:::
+:::{grid-item}
+:columns: 4
+On the right!
+:::
 ::::
 
 ## Margins and Sidebars

--- a/packages/myst-demo/src/index.tsx
+++ b/packages/myst-demo/src/index.tsx
@@ -111,7 +111,7 @@ async function parse(
   const { mystToHtml } = await import('myst-to-html');
   const { buttonRole } = await import('myst-ext-button');
   const { cardDirective } = await import('myst-ext-card');
-  const { gridDirective } = await import('myst-ext-grid');
+  const { gridDirectives } = await import('myst-ext-grid');
   const { tabDirectives } = await import('myst-ext-tabs');
   const { proofDirective } = await import('myst-ext-proof');
   const { exerciseDirectives } = await import('myst-ext-exercise');
@@ -121,7 +121,7 @@ async function parse(
       markdownit: { linkify: true },
       directives: [
         cardDirective,
-        gridDirective,
+        ...gridDirectives,
         ...tabDirectives,
         proofDirective,
         ...exerciseDirectives,

--- a/packages/myst-to-react/src/grid-item.tsx
+++ b/packages/myst-to-react/src/grid-item.tsx
@@ -1,0 +1,38 @@
+import classNames from 'classnames';
+import React from 'react';
+import type { NodeRenderer } from '@myst-theme/providers';
+import { MyST } from './MyST.js';
+
+type GridItemSpec = {
+  type: 'grid-item';
+  columns: number;
+};
+
+const colSpanClassNames = [
+  'col-span-1',
+  'col-span-2',
+  'col-span-3',
+  'col-span-4',
+  'col-span-5',
+  'col-span-6',
+  'col-span-7',
+  'col-span-8',
+  'col-span-9',
+  'col-span-10',
+  'col-span-11',
+  'col-span-12',
+];
+
+export const GridItemRenderer: NodeRenderer<GridItemSpec> = ({ node, className }) => {
+  return (
+    <div className={classNames('myst-grid-item', colSpanClassNames[node.columns - 1], className, node.class)}>
+      <MyST ast={node.children} />
+    </div>
+  );
+};
+
+const GRID_ITEM_RENDERERS = {
+  'grid-item': GridItemRenderer,
+};
+
+export default GRID_ITEM_RENDERERS;

--- a/packages/myst-to-react/src/grid-item.tsx
+++ b/packages/myst-to-react/src/grid-item.tsx
@@ -25,7 +25,14 @@ const colSpanClassNames = [
 
 export const GridItemRenderer: NodeRenderer<GridItemSpec> = ({ node, className }) => {
   return (
-    <div className={classNames('myst-grid-item', colSpanClassNames[node.columns - 1], className, node.class)}>
+    <div
+      className={classNames(
+        'myst-grid-item',
+        colSpanClassNames[node.columns - 1],
+        className,
+        node.class,
+      )}
+    >
       <MyST ast={node.children} />
     </div>
   );

--- a/packages/myst-to-react/src/grid-item.tsx
+++ b/packages/myst-to-react/src/grid-item.tsx
@@ -8,6 +8,7 @@ type GridItemSpec = {
   columns: number;
 };
 
+// See styles/index.js for the list of col classes that we import
 const colSpanClassNames = [
   'col-span-1',
   'col-span-2',

--- a/packages/myst-to-react/src/index.tsx
+++ b/packages/myst-to-react/src/index.tsx
@@ -5,6 +5,7 @@ import DROPDOWN_RENDERERS from './dropdown.js';
 import BLOCK_RENDERERS from './block.js';
 import CARD_RENDERERS from './card.js';
 import GRID_RENDERERS from './grid.js';
+import GRID_ITEM_RENDERERS from './grid-item.js';
 import CITE_RENDERERS from './cite.js';
 import FOOTNOTE_RENDERERS from './footnotes.js';
 import CODE_RENDERERS from './code.js';
@@ -54,6 +55,7 @@ export const DEFAULT_RENDERERS = mergeRenderers(
     DROPDOWN_RENDERERS,
     CARD_RENDERERS,
     GRID_RENDERERS,
+    GRID_ITEM_RENDERERS,
     INLINE_EXPRESSION_RENDERERS,
     EXT_RENDERERS,
     PROOF_RENDERERS,

--- a/styles/index.js
+++ b/styles/index.js
@@ -207,6 +207,12 @@ const safeList = [
   'col-span-4',
   'col-span-5',
   'col-span-6',
+  'col-span-7',
+  'col-span-8',
+  'col-span-9',
+  'col-span-10',
+  'col-span-11',
+  'col-span-12',
   // Utilities
   'shaded',
   'framed',


### PR DESCRIPTION
- Add renderer for `grid-item`
- Add missing tailwind classes for colspan

xref: https://github.com/jupyter-book/mystmd/pull/2766