### PR TITLE
Set netlify build branch from GitHub project

### DIFF
--- a/.github/tools/get-mystmd-branch.py
+++ b/.github/tools/get-mystmd-branch.py
@@ -6,7 +6,6 @@ URL and branch to clone.
 
 Project board: https://github.com/orgs/jupyter-book/projects/4
 
-
 Reads REVIEW_ID (PR number provided by Netlify) and GITHUB_TOKEN from
 the environment.
 

--- a/.github/tools/get-mystmd-branch.py
+++ b/.github/tools/get-mystmd-branch.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+"""
+Query the `mystmd-branch` field from the `Attach mystmd build
+branch to myst-theme PRs` GitHub project board, and print the git repo
+URL and branch to clone.
+
+Reads REVIEW_ID (PR number provided by Netlify) and GITHUB_TOKEN from
+the environment.
+
+Outputs: `<repo_url> <branch>` on stdout (defaults to `jupyter-book/mystmd main`).
+
+`mystmd-branch` may be:
+  - a plain branch name, e.g. `main` or `v0.22`    → jupyter-book/mystmd@<branch>
+  - `owner/branch`, e.g. `stefanv/my-feature`      → github.com/stefanv/mystmd@<branch>
+
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+DEFAULT_REPO_OWNER = "jupyter-book"
+DEFAULT_BRANCH = "main"
+PROJECT_NUMBER = 4
+
+QUERY = """
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        projectItems(first: 10) {
+          nodes {
+            project { number }
+            fieldValueByName(name: "mystmd-branch") {
+              ... on ProjectV2ItemFieldTextValue        { text }
+              ... on ProjectV2ItemFieldSingleSelectValue { name }
+            }
+          }
+        }
+      }
+    }
+  }
+"""
+
+
+def query_project_field(pr_number, github_token):
+    payload = json.dumps(
+        {
+            "query": QUERY,
+            "variables": {
+                "owner": "jupyter-book",
+                "repo": "myst-theme",
+                "pr": pr_number,
+            },
+        }
+    ).encode()
+
+    req = urllib.request.Request(
+        "https://api.github.com/graphql",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {github_token}",
+            "Content-Type": "application/json",
+        },
+    )
+
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read())
+
+    if "errors" in data:
+        messages = [e.get("message", str(e)) for e in data["errors"]]
+        print(f"Warning: GitHub API errors: {'; '.join(messages)}", file=sys.stderr)
+        sys.exit(1)
+
+    nodes = (
+        data.get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("projectItems", {})
+        .get("nodes", [])
+    )
+    for node in nodes:
+        if node and node.get("project", {}).get("number") == PROJECT_NUMBER:
+            fv = node.get("fieldValueByName") or {}
+            return fv.get("text") or fv.get("name")
+
+    return None
+
+
+def main():
+    review_id = os.environ.get("REVIEW_ID")
+    github_token = os.environ.get("GITHUB_TOKEN")
+
+    repo_owner = DEFAULT_REPO_OWNER
+    branch = DEFAULT_BRANCH
+
+    if review_id is None:
+        print("No REVIEW_ID set by Netlify; exiting.")
+        sys.exit(1)
+
+    if github_token is None:
+        print("No GITHUB_TOKEN set; exiting.")
+        sys.exit(1)
+
+    try:
+        value = query_project_field(int(review_id), github_token)
+        if value:
+            if "/" in value:
+                repo_owner, branch = value.split("/", 1)
+            else:
+                branch = value
+    except Exception as e:
+        print(f"Warning: failed to query mystmd-branch: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"https://github.com/{repo_owner}/mystmd.git {branch}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/tools/get-mystmd-branch.py
+++ b/.github/tools/get-mystmd-branch.py
@@ -4,6 +4,9 @@ Query the `mystmd-branch` field from the `Attach mystmd build
 branch to myst-theme PRs` GitHub project board, and print the git repo
 URL and branch to clone.
 
+Project board: https://github.com/orgs/jupyter-book/projects/4
+
+
 Reads REVIEW_ID (PR number provided by Netlify) and GITHUB_TOKEN from
 the environment.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,10 +5,15 @@
   environment = { PYTHON_VERSION = "3.12" }
   publish = "docs/_build/html"
   command = """
-    # Determine which mystmd branch to build against.
+    # Determine which mystmd branch to build against. By default, use `main`.
+    # You specify a different branch in the left-hand column of the PR:
+    # under Projects, expand the fields and fill out `mystmd-branch`.
+    #
     # For PR deploy previews, REVIEW_ID is set by Netlify to the PR number.
     # GITHUB_TOKEN must be set in Netlify env vars (read-only PAT, read:project scope)
-    # to query the project board. Falls back to "main" if unset or not a PR build.
+    # to query the project board (https://github.com/orgs/jupyter-book/projects/4).
+    #
+    # Falls back to `main` if unset or not a PR build.
     mystmd_branch=main
     if [ -n "$REVIEW_ID" ] && [ -n "$GITHUB_TOKEN" ]; then
       query='
@@ -28,6 +33,7 @@
           }
         }
       '
+      # Below, `argjson` (vs `arg`) is used because REVIEW_ID is a numerical value
       mystmd_branch=$(curl -sf \
         -H "Authorization: Bearer $GITHUB_TOKEN" \
         -H "Content-Type: application/json" \

--- a/netlify.toml
+++ b/netlify.toml
@@ -33,7 +33,7 @@
         }
       '
       # Below, `argjson` (vs `arg`) is used because REVIEW_ID is a numerical value
-      mystmd_branch=$(curl -sf \
+      response=$(curl -sf \
         -H "Authorization: Bearer $GITHUB_TOKEN" \
         -H "Content-Type: application/json" \
         -d "$(jq -cn \
@@ -42,24 +42,18 @@
           --argjson pr  "$REVIEW_ID" \
           --arg  query "$query" \
           '{query: $query, variables: {owner: $owner, repo: $repo, pr: $pr}}')" \
-        https://api.github.com/graphql \
-        | jq -r '
+        https://api.github.com/graphql) || true
+      if errors=$(echo "$response" | jq -r '.errors[]?.message // empty') && [ -n "$errors" ]; then
+        echo "Warning: GitHub API error querying mystmd-branch: $errors"
+        exit 1
+      else
+        mystmd_branch=$(echo "$response" | jq -r '
             .data.repository.pullRequest.projectItems.nodes[]
             | select(.project.number == 4)
             | .fieldValueByName
             | .text // .name // empty
-          ' | head -1) || true
-      echo $(curl -sf \
-        -H "Authorization: Bearer $GITHUB_TOKEN" \
-        -H "Content-Type: application/json" \
-        -d "$(jq -cn \
-          --arg  owner "jupyter-book" \
-          --arg  repo  "myst-theme" \
-          --argjson pr  "$REVIEW_ID" \
-          --arg  query "$query" \
-          '{query: $query, variables: {owner: $owner, repo: $repo, pr: $pr}}')" \
-        https://api.github.com/graphql)
-      echo $mystbd_branch
+          ' | head -1)
+      fi
       mystmd_branch="${mystmd_branch:-main}"
     fi &&
     echo "Building with mystmd from branch: $mystmd_branch" &&

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   publish = "docs/_build/html"
   command = """
     # Determine which mystmd branch to build against. By default, use `main`.
-    # You specify a different branch in the left-hand column of the PR:
+    # You specify a different branch in the right-hand column of the PR UI:
     # under Projects, expand the fields and fill out `mystmd-branch`.
     #
     # For PR deploy previews, REVIEW_ID is set by Netlify to the PR number.

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,8 +5,49 @@
   environment = { PYTHON_VERSION = "3.12" }
   publish = "docs/_build/html"
   command = """
-    # Clone and build mystmd from main branch
-    git clone --depth 1 https://github.com/jupyter-book/mystmd.git /tmp/mystmd && \
+    # Determine which mystmd branch to build against.
+    # For PR deploy previews, REVIEW_ID is set by Netlify to the PR number.
+    # GITHUB_TOKEN must be set in Netlify env vars (read-only PAT, read:project scope)
+    # to query the project board. Falls back to "main" if unset or not a PR build.
+    mystmd_branch=main
+    if [ -n "$REVIEW_ID" ] && [ -n "$GITHUB_TOKEN" ]; then
+      query='
+        query($owner: String!, $repo: String!, $pr: Int!) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $pr) {
+              projectItems(first: 10) {
+                nodes {
+                  project { number }
+                  fieldValueByName(name: "mystmd-branch") {
+                    ... on ProjectV2ItemFieldTextValue        { text }
+                    ... on ProjectV2ItemFieldSingleSelectValue { name }
+                  }
+                }
+              }
+            }
+          }
+        }
+      '
+      mystmd_branch=$(curl -sf \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -cn \
+          --arg  owner "jupyter-book" \
+          --arg  repo  "myst-theme" \
+          --argjson pr  "$REVIEW_ID" \
+          --arg  query "$query" \
+          '{query: $query, variables: {owner: $owner, repo: $repo, pr: $pr}}')" \
+        https://api.github.com/graphql \
+        | jq -r '
+            .data.repository.pullRequest.projectItems.nodes[]
+            | select(.project.number == 4)
+            | .fieldValueByName
+            | .text // .name
+          ' | head -1) || true
+      mystmd_branch="${mystmd_branch:-main}"
+    fi &&
+    # Clone and build mystmd from the resolved branch
+    git clone --depth 1 --branch "$mystmd_branch" https://github.com/jupyter-book/mystmd.git /tmp/mystmd && \
     cd /tmp/mystmd && \
     npm install && \
     npm run build && \

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,7 +14,6 @@
     # to query the project board (https://github.com/orgs/jupyter-book/projects/4).
     #
     # Falls back to `main` if unset or not a PR build.
-    mystmd_branch=main
     if [ -n "$REVIEW_ID" ] && [ -n "$GITHUB_TOKEN" ]; then
       query='
         query($owner: String!, $repo: String!, $pr: Int!) {
@@ -48,10 +47,11 @@
             .data.repository.pullRequest.projectItems.nodes[]
             | select(.project.number == 4)
             | .fieldValueByName
-            | .text // .name
+            | .text // .name // empty
           ' | head -1) || true
       mystmd_branch="${mystmd_branch:-main}"
     fi &&
+    echo "Building with mystmd from branch: $mystmd_branch" &&
     # Clone and build mystmd from the resolved branch
     git clone --depth 1 --branch "$mystmd_branch" https://github.com/jupyter-book/mystmd.git /tmp/mystmd && \
     cd /tmp/mystmd && \

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,56 +14,13 @@
     # to query the project board (https://github.com/orgs/jupyter-book/projects/4).
     #
     # Falls back to `main` if unset or not a PR build.
-    if [ -n "$REVIEW_ID" ] && [ -n "$GITHUB_TOKEN" ]; then
-      query='
-        query($owner: String!, $repo: String!, $pr: Int!) {
-          repository(owner: $owner, name: $repo) {
-            pullRequest(number: $pr) {
-              projectItems(first: 10) {
-                nodes {
-                  project { number }
-                  fieldValueByName(name: "mystmd-branch") {
-                    ... on ProjectV2ItemFieldTextValue        { text }
-                    ... on ProjectV2ItemFieldSingleSelectValue { name }
-                  }
-                }
-              }
-            }
-          }
-        }
-      '
-      # Below, `argjson` (vs `arg`) is used because REVIEW_ID is a numerical value
-      response=$(curl -sf \
-        -H "Authorization: Bearer $GITHUB_TOKEN" \
-        -H "Content-Type: application/json" \
-        -d "$(jq -cn \
-          --arg  owner "jupyter-book" \
-          --arg  repo  "myst-theme" \
-          --argjson pr  "$REVIEW_ID" \
-          --arg  query "$query" \
-          '{query: $query, variables: {owner: $owner, repo: $repo, pr: $pr}}')" \
-        https://api.github.com/graphql) || true
-      if errors=$(echo "$response" | jq -r '.errors[]?.message // empty') && [ -n "$errors" ]; then
-        echo "Warning: GitHub API error querying mystmd-branch: $errors"
-        exit 1
-      else
-        mystmd_branch=$(echo "$response" | jq -r '
-            .data.repository.pullRequest.projectItems.nodes[]
-            | select(.project.number == 4)
-            | .fieldValueByName
-            | .text // .name // empty
-          ' | head -1)
-      fi
-      mystmd_branch="${mystmd_branch:-main}"
-    fi &&
-    echo "Building with mystmd from branch: $mystmd_branch" &&
-    # Clone and build mystmd from the resolved branch
-    git clone --depth 1 --branch "$mystmd_branch" https://github.com/jupyter-book/mystmd.git /tmp/mystmd && \
+    read -r mystmd_url mystmd_ref < <(python .github/tools/get-mystmd-branch.py) &&
+    echo "Building with mystmd: $mystmd_url@$mystmd_ref" &&
+    (git clone --depth 1 --branch "$mystmd_ref" "$mystmd_url" /tmp/mystmd && \
     cd /tmp/mystmd && \
     npm install && \
     npm run build && \
-    npm run link && \
-    cd - && \
+    npm run link) && \
     # Build myst-theme
     npm install && \
     npm run build && \

--- a/netlify.toml
+++ b/netlify.toml
@@ -49,6 +49,17 @@
             | .fieldValueByName
             | .text // .name // empty
           ' | head -1) || true
+      echo $(curl -sf \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -cn \
+          --arg  owner "jupyter-book" \
+          --arg  repo  "myst-theme" \
+          --argjson pr  "$REVIEW_ID" \
+          --arg  query "$query" \
+          '{query: $query, variables: {owner: $owner, repo: $repo, pr: $pr}}')" \
+        https://api.github.com/graphql)
+      echo $mystbd_branch
       mystmd_branch="${mystmd_branch:-main}"
     fi &&
     echo "Building with mystmd from branch: $mystmd_branch" &&


### PR DESCRIPTION
This PR adds the ability to adjust the branch of `mystmd` that is used to build a PR.
This is useful for testing `myst-theme` PRs that also modify `mystmd`.

It gets the branch information by querying a custom field on a [github project board](https://github.com/orgs/jupyter-book/projects/4).