### PR TITLE
🧑‍🧑‍🧒‍🧒 Add `myst#children` unidirectional anywidget model interface

### DIFF
--- a/packages/anywidget/src/renderers.tsx
+++ b/packages/anywidget/src/renderers.tsx
@@ -14,6 +14,9 @@ import * as React from 'react';
 import classNames from 'classnames';
 import type { AnyWidget } from './types.js';
 import { MystAnyModel } from './models.js';
+import { MyST } from 'myst-to-react';
+
+export const MYST_PROP_CHILDREN = 'myst#children';
 
 export function AnyWidgetRenderer({ node }: { node: AnyWidget }) {
   // basic validation
@@ -23,6 +26,7 @@ export function AnyWidgetRenderer({ node }: { node: AnyWidget }) {
 
   const ref = React.useRef<HTMLDivElement>(null);
   const [error, setError] = React.useState<Error | null>(null);
+  const [children, setChildren] = React.useState<any[] | null>((node as any).children);
   React.useEffect(() => {
     // Reset error state on node change
     setError(null);
@@ -55,7 +59,13 @@ export function AnyWidgetRenderer({ node }: { node: AnyWidget }) {
         const widget = mod.default;
 
         // TODO: validate the widget
-        const model = new MystAnyModel(node.model);
+        const model = new MystAnyModel({ [MYST_PROP_CHILDREN]: children, ...node.model });
+
+        // Allow model to set children
+        model.on(`change:${MYST_PROP_CHILDREN}`, () => {
+          setChildren(model.get(MYST_PROP_CHILDREN) as any[]);
+        });
+
         maybeCleanupInitialize = await widget.initialize?.({ model });
 
         // Apply container classes
@@ -136,5 +146,10 @@ export function AnyWidgetRenderer({ node }: { node: AnyWidget }) {
     );
   }
 
-  return <div className="relative w-full" ref={ref} />;
+  return (
+    <>
+      <div className="relative w-full" ref={ref} />
+      <MyST ast={children ?? []} />
+    </>
+  );
 }

--- a/packages/anywidget/src/renderers.tsx
+++ b/packages/anywidget/src/renderers.tsx
@@ -15,6 +15,7 @@ import classNames from 'classnames';
 import type { AnyWidget } from './types.js';
 import { MystAnyModel } from './models.js';
 import { MyST } from 'myst-to-react';
+import type { GenericNode } from 'myst-common';
 
 export const MYST_PROP_CHILDREN = 'myst#children';
 
@@ -26,7 +27,7 @@ export function AnyWidgetRenderer({ node }: { node: AnyWidget }) {
 
   const ref = React.useRef<HTMLDivElement>(null);
   const [error, setError] = React.useState<Error | null>(null);
-  const [children, setChildren] = React.useState<any[] | null>((node as any).children);
+  const [children, setChildren] = React.useState<GenericNode[] | null>((node as any).children);
   React.useEffect(() => {
     // Reset error state on node change
     setError(null);
@@ -59,7 +60,8 @@ export function AnyWidgetRenderer({ node }: { node: AnyWidget }) {
         const widget = mod.default;
 
         // TODO: validate the widget
-        const model = new MystAnyModel({ [MYST_PROP_CHILDREN]: children, ...node.model });
+        const mystInterfaceState = { [MYST_PROP_CHILDREN]: children };
+        const model = new MystAnyModel({ ...mystInterfaceState, ...node.model });
 
         // Allow model to set children
         model.on(`change:${MYST_PROP_CHILDREN}`, () => {


### PR DESCRIPTION
This PR prototypes a reserved `myst#` interface for MyST-specific anywidget properties. In this first implementation there is support for passing in `children` from the `anywidget` node to the model, and subsequently reflecting changes to the model state into the AST.

See https://github.com/agoose77/example-anywidget-table/pull/1 for a demo of this:

<img width="740" height="287" alt="image" src="https://github.com/user-attachments/assets/da2e7e11-e1e7-4ed4-abdc-b6546f5a803d" />


The goal is to facilitate _portable_ node renderers such as gallery widgets that leverage MyST rendering but enhanced with runtime behaviour like filtering and sorting. It is already possible to do this by vendoring myst-to-react:

https://github.com/agoose77/example-anywidget-table

But this requires the anywidget to deal with the consequences of being isolated in its own React context and shadow DOM. By adding an interface for `children` rendering, we can ensure that the children renderer lives outside the shadow DOM (and make AST-tweaking widgets smaller and more robust). For example, here's a naive vendoring of `myst-to-react` alternative:

<img width="775" height="224" alt="image" src="https://github.com/user-attachments/assets/baf1e64c-f50e-4dd8-86f4-011831f2b539" />

## To Do
- [x] Fix up types