### PR TITLE
🐛 Fix netlify branch script for our theme docs

### DIFF
--- a/.github/tools/get-mystmd-branch.py
+++ b/.github/tools/get-mystmd-branch.py
@@ -99,11 +99,11 @@ def main():
     branch = DEFAULT_BRANCH
 
     if review_id is None:
-        print("No REVIEW_ID set by Netlify; exiting.")
-        sys.exit(1)
+        print(f"https://github.com/{repo_owner}/mystmd.git {branch}")
+        sys.exit(0)
 
     if github_token is None:
-        print("No GITHUB_TOKEN set; exiting.")
+        print("No GITHUB_TOKEN set; exiting.", file=sys.stderr)
         sys.exit(1)
 
     try:


### PR DESCRIPTION
We are exiting `1` when there's no netlify branch target, but I think we want to exit `(0)` instead because on `main` we don't expect that target to exist, and currently it's causing netlify build failures