### PR TITLE
Document grid system without storybook

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -47,6 +47,7 @@ site:
     - title: Developer page
       url: /developer
   options:
+    style: public/layout-demo.css
     site_title: myst-theme documentation
     folders: true
     logo: _static/myst-logo-light.svg

--- a/docs/public/layout-demo.css
+++ b/docs/public/layout-demo.css
@@ -1,0 +1,28 @@
+/* Styles for the grid system layout demo in docs/reference/layout.md */
+
+/* Base demo item style — widths come from the actual col-* grid classes */
+.layout-demo {
+  border-radius: 0.375rem;
+  padding: 0.5rem;
+  font-family: monospace;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-align: center;
+  margin-top: 0.25rem !important;
+}
+
+/* Color coding per region */
+.layout-demo-col-screen            { background: #dbeafe; border: 1px solid #93c5fd; }
+.layout-demo-col-page              { background: #cffafe; border: 1px solid #67e8f9; }
+.layout-demo-col-page-inset        { background: #e0f2fe; border: 1px solid #7dd3fc; }
+.layout-demo-col-body-outset       { background: #d1fae5; border: 1px solid #6ee7b7; }
+.layout-demo-col-body              { background: #dcfce7; border: 1px solid #86efac; }
+.layout-demo-col-body-inset        { background: #fef9c3; border: 1px solid #fde047; }
+.layout-demo-col-middle            { background: #fef3c7; border: 1px solid #fcd34d; }
+.layout-demo-col-margin-left       { background: #fce7f3; border: 1px solid #f9a8d4; }
+.layout-demo-col-margin            { background: #ffe4e6; border: 1px solid #fca5a5; }
+.layout-demo-col-margin-right-inset { background: #fff1f2; border: 1px solid #fecdd3; }
+.layout-demo-col-body-left         { background: #ecfdf5; border: 1px solid #6ee7b7; }
+.layout-demo-col-body-right        { background: #f0fdf4; border: 1px solid #86efac; }
+.layout-demo-col-gutter            { background: #f1f5f9; border: 1px solid #cbd5e1; }
+.layout-demo-col-gutter-page       { background: #f8fafc; border: 1px solid #e2e8f0; }

--- a/docs/reference/layout.md
+++ b/docs/reference/layout.md
@@ -1,0 +1,233 @@
+# Page Layout
+
+The myst-theme page layout is built on a CSS grid system with three variants.
+Each bar below uses the actual CSS class as its label.
+Each is generated with the `{div}` directive.
+
+We intentionally leave the primary and secondary sidebars visible so that you can see how they relate to one another in size, but normally you'd remove one or the other if you wanted to use many of these classes.
+
+## `article-grid`
+
+:::::{div}
+:class: col-page not-prose
+
+::::{div}
+:class: article-grid grid-gap
+
+:::{div}
+:class: layout-demo layout-demo-col-screen col-screen
+col-screen
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-page col-page
+col-page
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-page-inset col-page-inset
+col-page-inset
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body-outset col-body-outset
+col-body-outset
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body col-body
+col-body (default)
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body-inset col-body-inset
+col-body-inset
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-middle col-middle
+col-middle
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-margin-left col-margin-left
+col-margin-left
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body col-body
+col-body
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-margin col-margin
+col-margin
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-margin-right-inset col-margin-right-inset
+col-margin-right-inset
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body-left col-body-left
+col-body-left
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body-right col-body-right
+col-body-right
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-gutter col-gutter-left
+col-gutter-left
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-gutter col-gutter-right
+col-gutter-right
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-gutter-page col-gutter-page-left
+col-gutter-page-left
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-gutter-page col-gutter-page-right
+col-gutter-page-right
+:::
+
+::::
+
+:::::
+
+## `article-left-grid`
+
+:::::{div}
+:class: col-page not-prose
+
+::::{div}
+:class: article-left-grid grid-gap
+
+:::{div}
+:class: layout-demo layout-demo-col-screen col-screen
+col-screen
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-page col-page
+col-page
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-page-inset col-page-inset
+col-page-inset
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body-outset col-body-outset
+col-body-outset
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body col-body
+col-body (default)
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body-inset col-body-inset
+col-body-inset
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-middle col-middle
+col-middle
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-margin-left col-margin-left
+col-margin-left
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body col-body
+col-body
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-margin col-margin
+col-margin
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-margin-right-inset col-margin-right-inset
+col-margin-right-inset
+:::
+
+::::
+
+:::::
+
+## `article-center-grid`
+
+:::::{div}
+:class: col-page not-prose
+
+::::{div}
+:class: article-center-grid grid-gap
+
+:::{div}
+:class: layout-demo layout-demo-col-screen col-screen
+col-screen
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-page col-page
+col-page
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-page-inset col-page-inset
+col-page-inset
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body-outset col-body-outset
+col-body-outset
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body col-body
+col-body (default)
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body-inset col-body-inset
+col-body-inset
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-middle col-middle
+col-middle
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-margin-left col-margin-left
+col-margin-left
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-body col-body
+col-body
+:::
+
+:::{div}
+:class: layout-demo layout-demo-col-margin col-margin
+col-margin
+:::
+
+::::
+
+:::::


### PR DESCRIPTION
This adds a `layout.md` page to our reference documentation that (I think) uses all of the CSS classes that we demo in the grid system on storybook. It basically just puts them all in divs so you can see how they look, with a little bit of styling to make them look nice.

[Demo here](https://deploy-preview-847--myst-theme.netlify.app/reference/layout/)

---

- closes #829 