### PR TITLE
Make stderr and stdout from code cells scrollable if they overflow

### DIFF
--- a/.changeset/forty-parents-ring.md
+++ b/.changeset/forty-parents-ring.md
@@ -1,0 +1,7 @@
+---
+'myst-to-react': patch
+'@myst-theme/providers': patch
+'@myst-theme/jupyter': patch
+---
+
+Make overflowing content focusable

--- a/docs/reference/blocks.md
+++ b/docs/reference/blocks.md
@@ -32,6 +32,15 @@ def calculate_sum(a, b):
     return result
 ```
 
+### Wide Code Block
+
+This code block has long lines and should be horizontally scrollable. Keyboard users should be able to tab to it and scroll with arrow keys.
+
+```python
+def print_a_really_long_string():
+    print("MyST is really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really neat!")
+```
+
 ## Blockquotes
 
 > Basic blockquote for quoted text.

--- a/docs/reference/computation.md
+++ b/docs/reference/computation.md
@@ -20,6 +20,7 @@ These cells produce wide outputs to test that scrollable regions are keyboard-ac
 ```{code-cell} python
 def print_a_really_long_string():
     print("MyST is really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really neat!")
+print_a_really_long_string()
 ```
 
 ## Pandas

--- a/docs/reference/computation.md
+++ b/docs/reference/computation.md
@@ -13,16 +13,6 @@ This page contains example content for previewing or demonstrating computational
 The [Example Outputs Site](https://jupyter-book.github.io/example-outputs/) has more comprehensive examples to show off MyST generating outputs with computation.
 :::
 
-## Wide cell inputs and outputs
-
-These cells produce wide outputs to test that scrollable regions are keyboard-accessible (tab to focus, arrow keys to scroll).
-
-```{code-cell} python
-def print_a_really_long_string():
-    print("MyST is really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really neat!")
-print_a_really_long_string()
-```
-
 ## Pandas
 
 ```{code-cell}
@@ -98,4 +88,14 @@ p.yaxis.axis_label = 'Column B'
 p.grid.grid_line_alpha = 0.3
 
 show(p)
+```
+
+## Wide cell inputs and outputs
+
+These cells produce wide outputs to test that scrollable regions are keyboard-accessible (tab to focus, arrow keys to scroll).
+
+```{code-cell} python
+def print_a_really_long_string():
+    print("MyST is really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really neat!")
+print_a_really_long_string()
 ```

--- a/docs/reference/computation.md
+++ b/docs/reference/computation.md
@@ -13,6 +13,15 @@ This page contains example content for previewing or demonstrating computational
 The [Example Outputs Site](https://jupyter-book.github.io/example-outputs/) has more comprehensive examples to show off MyST generating outputs with computation.
 :::
 
+## Wide cell inputs and outputs
+
+These cells produce wide outputs to test that scrollable regions are keyboard-accessible (tab to focus, arrow keys to scroll).
+
+```{code-cell} python
+def print_a_really_long_string():
+    print("MyST is really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really neat!")
+```
+
 ## Pandas
 
 ```{code-cell}

--- a/docs/reference/tables.md
+++ b/docs/reference/tables.md
@@ -39,3 +39,10 @@ title: Tables
 |--------|---:|---:|---:|
 | Revenue | $125K | $138K | $142K |
 | Growth | 8.5% | 10.4% | 2.9% |
+
+## Wide Table
+
+| Col 1 | Col 2 | Col 3 | Col 4 | Col 5 | Col 6 | Col 7 | Col 8 | Col 9 | Col 10 | Col 11 | Col 12 | Col 13 | Col 14 | Col 15 | Col 16 | Col 17 | Col 18 | Col 19 | Col 20 | Col 21 | Col 22 | Col 23 | Col 24 | Col 25 | Col 26 | Col 27 | Col 28 | Col 29 | Col 30 | Col 31 | Col 32 | Col 33 | Col 34 | Col 35 | Col 36 | Col 37 | Col 38 | Col 39 | Col 40 |
+|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
+| Data A1 | Data A2 | Data A3 | Data A4 | Data A5 | Data A6 | Data A7 | Data A8 | Data A9 | Data A10 | Data A11 | Data A12 | Data A13 | Data A14 | Data A15 | Data A16 | Data A17 | Data A18 | Data A19 | Data A20 | Data A21 | Data A22 | Data A23 | Data A24 | Data A25 | Data A26 | Data A27 | Data A28 | Data A29 | Data A30 | Data A31 | Data A32 | Data A33 | Data A34 | Data A35 | Data A36 | Data A37 | Data A38 | Data A39 | Data A40 |
+| Data B1 | Data B2 | Data B3 | Data B4 | Data B5 | Data B6 | Data B7 | Data B8 | Data B9 | Data B10 | Data B11 | Data B12 | Data B13 | Data B14 | Data B15 | Data B16 | Data B17 | Data B18 | Data B19 | Data B20 | Data B21 | Data B22 | Data B23 | Data B24 | Data B25 | Data B26 | Data B27 | Data B28 | Data B29 | Data B30 | Data B31 | Data B32 | Data B33 | Data B34 | Data B35 | Data B36 | Data B37 | Data B38 | Data B39 | Data B40 |

--- a/packages/jupyter/src/error.tsx
+++ b/packages/jupyter/src/error.tsx
@@ -2,19 +2,40 @@ import Ansi from '@curvenote/ansi-to-react';
 import { ensureString } from 'nbtx';
 import type { MinifiedErrorOutput } from 'nbtx';
 import { MaybeLongContent } from './components.js';
+import React, { useRef, useState, useEffect } from 'react';
 
 export default function Error({ output }: { output: MinifiedErrorOutput }) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [isScrollable, setIsScrollable] = useState(false);
+
+  useEffect(() => {
+    const el = preRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(() => {
+      // Check for horizontal overflow
+      setIsScrollable(el.scrollWidth > el.clientWidth);
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <MaybeLongContent
       content={ensureString(output.traceback)}
       path={output.path}
-      render={(content?: string) => {
-        return (
-          <pre className="myst-jp-error-output text-sm font-thin font-system jupyter-error">
-            <Ansi>{content ?? ''}</Ansi>
-          </pre>
-        );
-      }}
+      render={(content?: string) => (
+        <pre 
+          ref={preRef}
+          tabIndex={isScrollable ? 0 : undefined}
+          role={isScrollable ? 'region' : undefined}
+          aria-label="error output"
+          className="myst-jp-error-output text-sm font-thin font-system jupyter-error overflow-auto"
+        >
+          <Ansi>{content ?? ''}</Ansi>
+        </pre>
+      )}
     />
   );
 }

--- a/packages/jupyter/src/error.tsx
+++ b/packages/jupyter/src/error.tsx
@@ -26,7 +26,7 @@ export default function Error({ output }: { output: MinifiedErrorOutput }) {
       content={ensureString(output.traceback)}
       path={output.path}
       render={(content?: string) => (
-        <pre 
+        <pre
           ref={preRef}
           tabIndex={isScrollable ? 0 : undefined}
           role={isScrollable ? 'region' : undefined}

--- a/packages/jupyter/src/error.tsx
+++ b/packages/jupyter/src/error.tsx
@@ -2,24 +2,10 @@ import Ansi from '@curvenote/ansi-to-react';
 import { ensureString } from 'nbtx';
 import type { MinifiedErrorOutput } from 'nbtx';
 import { MaybeLongContent } from './components.js';
-import React, { useRef, useState, useEffect } from 'react';
+import { useIsScrollable } from '@myst-theme/providers';
 
 export default function Error({ output }: { output: MinifiedErrorOutput }) {
-  const preRef = useRef<HTMLPreElement>(null);
-  const [isScrollable, setIsScrollable] = useState(false);
-
-  useEffect(() => {
-    const el = preRef.current;
-    if (!el) return;
-
-    const observer = new ResizeObserver(() => {
-      // Check for horizontal overflow
-      setIsScrollable(el.scrollWidth > el.clientWidth);
-    });
-
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
+  const { ref, isScrollable } = useIsScrollable<HTMLPreElement>();
 
   return (
     <MaybeLongContent
@@ -27,10 +13,10 @@ export default function Error({ output }: { output: MinifiedErrorOutput }) {
       path={output.path}
       render={(content?: string) => (
         <pre
-          ref={preRef}
+          ref={ref}
           tabIndex={isScrollable ? 0 : undefined}
           role={isScrollable ? 'region' : undefined}
-          aria-label="error output"
+          aria-label="cell error output"
           className="myst-jp-error-output text-sm font-thin font-system jupyter-error overflow-auto"
         >
           <Ansi>{content ?? ''}</Ansi>

--- a/packages/jupyter/src/stream.tsx
+++ b/packages/jupyter/src/stream.tsx
@@ -2,23 +2,10 @@ import Ansi from '@curvenote/ansi-to-react';
 import { ensureString } from 'nbtx';
 import type { MinifiedStreamOutput } from 'nbtx';
 import { MaybeLongContent } from './components.js';
-import React, { useRef, useState, useEffect } from 'react';
+import { useIsScrollable } from '@myst-theme/providers';
 
 export default function Stream({ output }: { output: MinifiedStreamOutput }) {
-  const preRef = useRef<HTMLPreElement>(null);
-  const [isScrollable, setIsScrollable] = useState(false);
-
-  useEffect(() => {
-    const el = preRef.current;
-    if (!el) return;
-
-    const observer = new ResizeObserver(() => {
-      setIsScrollable(el.scrollWidth > el.clientWidth);
-    });
-
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
+  const { ref, isScrollable } = useIsScrollable<HTMLPreElement>();
 
   return (
     <MaybeLongContent
@@ -26,10 +13,10 @@ export default function Stream({ output }: { output: MinifiedStreamOutput }) {
       path={output.path}
       render={(content?: string) => (
         <pre
-          ref={preRef} // 2. Attach the ref here
-          tabIndex={isScrollable ? 0 : undefined} // 3. Add accessibility
+          ref={ref}
+          tabIndex={isScrollable ? 0 : undefined}
           role={isScrollable ? 'region' : undefined}
-          aria-label="output stream"
+          aria-label="cell output stream"
           className="myst-jp-stream-output text-sm font-thin font-system overflow-auto"
         >
           <Ansi>{content ?? ''}</Ansi>

--- a/packages/jupyter/src/stream.tsx
+++ b/packages/jupyter/src/stream.tsx
@@ -2,14 +2,36 @@ import Ansi from '@curvenote/ansi-to-react';
 import { ensureString } from 'nbtx';
 import type { MinifiedStreamOutput } from 'nbtx';
 import { MaybeLongContent } from './components.js';
+import React, { useRef, useState, useEffect } from 'react';
 
 export default function Stream({ output }: { output: MinifiedStreamOutput }) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [isScrollable, setIsScrollable] = useState(false);
+
+  useEffect(() => {
+    const el = preRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(() => {
+      setIsScrollable(el.scrollWidth > el.clientWidth);
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <MaybeLongContent
       content={ensureString(output.text)}
       path={output.path}
       render={(content?: string) => (
-        <pre className="myst-jp-stream-output text-sm font-thin font-system">
+        <pre 
+          ref={preRef} // 2. Attach the ref here
+          tabIndex={isScrollable ? 0 : undefined} // 3. Add accessibility
+          role={isScrollable ? 'region' : undefined}
+          aria-label="output stream"
+          className="myst-jp-stream-output text-sm font-thin font-system overflow-auto"
+        >
           <Ansi>{content ?? ''}</Ansi>
         </pre>
       )}

--- a/packages/jupyter/src/stream.tsx
+++ b/packages/jupyter/src/stream.tsx
@@ -25,7 +25,7 @@ export default function Stream({ output }: { output: MinifiedStreamOutput }) {
       content={ensureString(output.text)}
       path={output.path}
       render={(content?: string) => (
-        <pre 
+        <pre
           ref={preRef} // 2. Attach the ref here
           tabIndex={isScrollable ? 0 : undefined} // 3. Add accessibility
           role={isScrollable ? 'region' : undefined}

--- a/packages/myst-to-react/src/code.tsx
+++ b/packages/myst-to-react/src/code.tsx
@@ -8,7 +8,6 @@ import React, { useMemo, useState, useRef, useEffect } from 'react';
 import type { ComponentProps } from 'react';
 import { Details } from './dropdown.js';
 
-
 type Props = {
   value: string;
   identifier?: string;

--- a/packages/myst-to-react/src/code.tsx
+++ b/packages/myst-to-react/src/code.tsx
@@ -4,9 +4,10 @@ import { DocumentIcon } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
 import { CopyIcon } from './components/index.js';
 import { MyST } from './MyST.js';
-import React, { useMemo, useState, useRef, useEffect } from 'react';
+import { useMemo } from 'react';
 import type { ComponentProps } from 'react';
 import { Details } from './dropdown.js';
+import { useIsScrollable } from '@myst-theme/providers';
 
 type Props = {
   value: string;
@@ -49,22 +50,7 @@ export function CodeBlock(props: Props) {
     background,
     border,
   } = props;
-  const highlighterRef = useRef<HTMLDivElement>(null);
-  const [isScrollable, setIsScrollable] = useState(false);
-
-  useEffect(() => {
-    const el = highlighterRef.current;
-    if (!el) return;
-
-    // Check for overflow dynamically
-    const observer = new ResizeObserver(() => {
-      const horizontalOverflow = el.scrollWidth > el.clientWidth;
-      setIsScrollable(horizontalOverflow);
-    });
-
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
+  const { ref: highlighterRef, isScrollable } = useIsScrollable<HTMLDivElement>();
   const highlighterProps: Omit<HighlightPropsType, 'children'> = useMemo(() => {
     const highlightLines = new Set(emphasizeLines);
     return {
@@ -121,18 +107,16 @@ export function CodeBlock(props: Props) {
         </div>
       )}
 
-      {/* scrollable region */}
       <div
         ref={highlighterRef}
         tabIndex={isScrollable ? 0 : undefined}
         role={isScrollable ? 'region' : undefined}
-        aria-label={isScrollable ? 'code snippet' : undefined}
+        aria-label="code block content"
         className="block overflow-auto p-3 myst-code-body hljs"
       >
         <SyntaxHighlighter
           {...highlighterProps}
-          className="bg-transparent"
-          customStyle={{ padding: 0, margin: 0, backgroundColor: 'transparent' }}
+          customStyle={{ padding: 0, margin: 0, background: 'transparent' }}
         >
           {value}
         </SyntaxHighlighter>

--- a/packages/myst-to-react/src/code.tsx
+++ b/packages/myst-to-react/src/code.tsx
@@ -4,9 +4,10 @@ import { DocumentIcon } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
 import { CopyIcon } from './components/index.js';
 import { MyST } from './MyST.js';
-import { useMemo } from 'react';
+import React, { useMemo, useState, useRef, useEffect } from 'react';
 import type { ComponentProps } from 'react';
 import { Details } from './dropdown.js';
+
 
 type Props = {
   value: string;
@@ -49,6 +50,22 @@ export function CodeBlock(props: Props) {
     background,
     border,
   } = props;
+  const highlighterRef = useRef<HTMLDivElement>(null);
+  const [isScrollable, setIsScrollable] = useState(false);
+
+  useEffect(() => {
+    const el = highlighterRef.current;
+    if (!el) return;
+
+    // Check for overflow dynamically
+    const observer = new ResizeObserver(() => {
+      const horizontalOverflow = el.scrollWidth > el.clientWidth;
+      setIsScrollable(horizontalOverflow);
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
   const highlighterProps: Omit<HighlightPropsType, 'children'> = useMemo(() => {
     const highlightLines = new Set(emphasizeLines);
     return {
@@ -104,12 +121,24 @@ export function CodeBlock(props: Props) {
           </div>
         </div>
       )}
-      <SyntaxHighlighter
-        {...highlighterProps}
+
+      {/* scrollable region */}
+      <div
+        ref={highlighterRef}
+        tabIndex={isScrollable ? 0 : undefined}
+        role={isScrollable ? 'region' : undefined}
+        aria-label={isScrollable ? 'code snippet' : undefined}
         className="block overflow-auto p-3 myst-code-body hljs"
       >
-        {value}
-      </SyntaxHighlighter>
+        <SyntaxHighlighter
+          {...highlighterProps}
+          className="bg-transparent"
+          customStyle={{ padding: 0, margin: 0, backgroundColor: 'transparent' }}
+        >
+          {value}
+        </SyntaxHighlighter>
+      </div>
+
       {showCopy && (
         <CopyIcon
           text={value}

--- a/packages/providers/src/hooks.ts
+++ b/packages/providers/src/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 // Based on https://usehooks-ts.com/react-hook/use-media-query
 export function useMediaQuery(query: string): boolean {
@@ -27,4 +27,25 @@ export function useMediaQuery(query: string): boolean {
   }, [query]);
 
   return matches;
+}
+
+/**
+ * Returns a ref and a boolean indicating whether the element has horizontal overflow.
+ * We use this to make scrollable regions keyboard-accessible if they are wide.
+ */
+export function useIsScrollable<T extends HTMLElement>() {
+  const ref = useRef<T>(null);
+  const [isScrollable, setIsScrollable] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      setIsScrollable(el.scrollWidth > el.clientWidth);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, isScrollable };
 }


### PR DESCRIPTION
Closes #743 

This PR ensures that users who navigate with a keyboard are able to view (potentially) scrollable code/code output regions. I've tested for the code cells themselves, normal output, and output with errors.

UC Berkeley (who deploys multiple online textbooks with Jupyter Book) is required by law to meet this standard by [April 24](https://dap.berkeley.edu/ada-title-ii-updates/ada-title-ii-updates-what-does-it-mean-us), so I'd LOVE to get this merged by then. I'm planning to attend the collaboration cafe on April 7 to at the very least touch base about this PR, if not merge it.

This is a narrow fix for scrollable regions relating to code cells and their output. Other potentially scrollable regions (like tables) likely still present accessibility violations. 

Tested with [axe devTools chrome extension](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US)

I'm not the most familiar with React, so please point out any potential problems with this (bonus points if you link me to resources).