### PR TITLE
Fix wide tables overflow

### DIFF
--- a/.changeset/metal-falcons-cheer.md
+++ b/.changeset/metal-falcons-cheer.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Add aria tags to overflowing tables

--- a/docs/reference/tables.md
+++ b/docs/reference/tables.md
@@ -35,7 +35,16 @@ title: Tables
 
 ## Wide Table
 
+(a-wide-table)=
 | Col 1 | Col 2 | Col 3 | Col 4 | Col 5 | Col 6 | Col 7 | Col 8 | Col 9 | Col 10 | Col 11 | Col 12 | Col 13 | Col 14 | Col 15 | Col 16 | Col 17 | Col 18 | Col 19 | Col 20 | Col 21 | Col 22 | Col 23 | Col 24 | Col 25 | Col 26 | Col 27 | Col 28 | Col 29 | Col 30 | Col 31 | Col 32 | Col 33 | Col 34 | Col 35 | Col 36 | Col 37 | Col 38 | Col 39 | Col 40 |
 |:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
 | Data A1 | Data A2 | Data A3 | Data A4 | Data A5 | Data A6 | Data A7 | Data A8 | Data A9 | Data A10 | Data A11 | Data A12 | Data A13 | Data A14 | Data A15 | Data A16 | Data A17 | Data A18 | Data A19 | Data A20 | Data A21 | Data A22 | Data A23 | Data A24 | Data A25 | Data A26 | Data A27 | Data A28 | Data A29 | Data A30 | Data A31 | Data A32 | Data A33 | Data A34 | Data A35 | Data A36 | Data A37 | Data A38 | Data A39 | Data A40 |
 | Data B1 | Data B2 | Data B3 | Data B4 | Data B5 | Data B6 | Data B7 | Data B8 | Data B9 | Data B10 | Data B11 | Data B12 | Data B13 | Data B14 | Data B15 | Data B16 | Data B17 | Data B18 | Data B19 | Data B20 | Data B21 | Data B22 | Data B23 | Data B24 | Data B25 | Data B26 | Data B27 | Data B28 | Data B29 | Data B30 | Data B31 | Data B32 | Data B33 | Data B34 | Data B35 | Data B36 | Data B37 | Data B38 | Data B39 | Data B40 |
+
++++
+
+In an admonition to test overflow within elements:
+
+```{note} A wide table!
+![](#a-wide-table)
+```

--- a/docs/reference/tables.md
+++ b/docs/reference/tables.md
@@ -26,13 +26,6 @@ title: Tables
 | `Code` | ✓ | Also works |
 | [Links](https://mystmd.org) | ✓ | External links |
 
-## Wide Table
-
-| Col 1 | Col 2 | Col 3 | Col 4 | Col 5 | Col 6 |
-|-------|-------|-------|-------|-------|-------|
-| A1    | A2    | A3    | A4    | A5    | A6    |
-| B1    | B2    | B3    | B4    | B5    | B6    |
-
 ## With Numbers
 
 | Metric | Q1 | Q2 | Q3 |

--- a/packages/myst-to-react/src/basic.tsx
+++ b/packages/myst-to-react/src/basic.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import type * as spec from 'myst-spec';
 import { HashLink } from './hashLink.js';
-import type { NodeRenderer } from '@myst-theme/providers';
-import { useIsScrollable } from '@myst-theme/providers';
+import { type NodeRenderer, useIsScrollable } from '@myst-theme/providers';
 import classNames from 'classnames';
 import { Tooltip } from './components/index.js';
 import { MyST } from './MyST.js';

--- a/packages/myst-to-react/src/basic.tsx
+++ b/packages/myst-to-react/src/basic.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type * as spec from 'myst-spec';
 import { HashLink } from './hashLink.js';
 import type { NodeRenderer } from '@myst-theme/providers';
+import { useIsScrollable } from '@myst-theme/providers';
 import classNames from 'classnames';
 import { Tooltip } from './components/index.js';
 import { MyST } from './MyST.js';
@@ -304,12 +305,21 @@ const BASIC_RENDERERS: BasicNodeRenderers = {
   },
   table({ node, className }) {
     // TODO: actually render the tbody on the server if it isn't included here.
+    const { ref, isScrollable } = useIsScrollable<HTMLDivElement>();
     return (
-      <table className={classNames(node.class, className)} style={node.style}>
-        <tbody>
-          <MyST ast={node.children} />
-        </tbody>
-      </table>
+      <div
+        ref={ref}
+        tabIndex={isScrollable ? 0 : undefined}
+        role={isScrollable ? 'region' : undefined}
+        aria-label="table content"
+        className="overflow-auto"
+      >
+        <table className={classNames(node.class, className)} style={node.style}>
+          <tbody>
+            <MyST ast={node.children} />
+          </tbody>
+        </table>
+      </div>
     );
   },
   tableRow({ node, className }) {


### PR DESCRIPTION
This adds the same `useIsScrollable` logic to tables by wrapping them in a div and adding the scroll logic to it. Here's a GIF of how the broken example now looks on this branch:

![CleanShot 2026-04-07 at 15 12 13](https://github.com/user-attachments/assets/05013cdd-9cce-4bad-9712-bb8997231c09)

---

- closes #851 