### PR TITLE
Destructure aria-controls and only use it when its target exists in search

### DIFF
--- a/.changeset/silent-kids-start.md
+++ b/.changeset/silent-kids-start.md
@@ -1,0 +1,8 @@
+---
+'myst-to-react': patch
+'@myst-theme/providers': patch
+'@myst-theme/jupyter': patch
+'@myst-theme/site': patch
+---
+
+Fix aria-controls in search popup

--- a/.changeset/silent-kids-start.md
+++ b/.changeset/silent-kids-start.md
@@ -1,7 +1,4 @@
 ---
-'myst-to-react': patch
-'@myst-theme/providers': patch
-'@myst-theme/jupyter': patch
 '@myst-theme/site': patch
 ---
 

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -557,9 +557,15 @@ const SearchPlaceholderButton = forwardRef<
   HTMLButtonElement,
   SearchPlaceholderButtonProps & Dialog.DialogTriggerProps
 >(({ className, disabled, ...props }, ref) => {
+  // Here we remove aria-controls from props so we can *decide* whether to insert it later
+  // This is because radix has a bug where it'll try pointing to a non-existent element
+  // if the dialog isn't open, so that's the logic we test below.
+  // ref: https://github.com/radix-ui/primitives/issues/3560
+  const { 'aria-controls': ariaControls, ...restProps } = props;
   return (
     <button
-      {...props}
+      {...restProps}
+      aria-controls={restProps['aria-expanded'] === 'true' ? ariaControls : undefined}
       className={classNames(
         'myst-search-bar',
         className,

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -565,7 +565,7 @@ const SearchPlaceholderButton = forwardRef<
   return (
     <button
       {...restProps}
-      aria-controls={restProps['aria-expanded'] === 'true' ? ariaControls : undefined}
+      aria-controls={restProps['aria-expanded'] ? ariaControls : undefined}
       className={classNames(
         'myst-search-bar',
         className,


### PR DESCRIPTION
This is a quick fix for the aria-controls bug that @erikamov reported!

I think that we might have similar bugs (that are less-common to trigger) in other places where we have "pop up" menus (e.g. launch buttons) but didn't have time to investigate and just wanna get this fix in

---

- closes https://github.com/jupyter-book/myst-theme/issues/808