### PR TITLE
Improve search accessibility

### DIFF
--- a/.changeset/busy-games-find.md
+++ b/.changeset/busy-games-find.md
@@ -2,4 +2,5 @@
 '@myst-theme/site': patch
 ---
 
-Add aria-label and other annotations to search items
+Re-order search entries to better behave under screen-readers.
+Add missing aria-expanded attribute.

--- a/.changeset/busy-games-find.md
+++ b/.changeset/busy-games-find.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/site': patch
+---
+
+Add aria-label and other annotations to search items

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -525,7 +525,6 @@ function SearchForm({
               { 'border-red-500': !enabled },
             )}
             id={searchInputID}
-            role="combobox"
             aria-labelledby={searchLabelID}
             aria-controls={searchListID}
             aria-expanded={!!searchResults}

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -361,9 +361,15 @@ function SearchResults({
     },
     [onHoverSelect],
   );
+  const searchResultsWithAria = useMemo(() => {
+    return searchResults.map((result) => {
+      const ariaLabel = getResultAriaLabel(result);
+      return { result, ariaLabel };
+    });
+  }, [searchResults]);
   return (
     <div className="myst-search-results mt-4 overflow-y-scroll">
-      {searchResults.length ? (
+      {searchResultsWithAria.length ? (
         <ul
           // Accessiblity:
           // indicate that this is a selectbox
@@ -376,7 +382,7 @@ function SearchResults({
           aria-activedescendant={activeDescendent}
           className={classNames('flex flex-col gap-y-2 px-1', className)}
         >
-          {searchResults.map((result, index) => (
+          {searchResultsWithAria.map(({ result, ariaLabel }, index) => (
             <li
               key={result.id}
               ref={setItemRef}
@@ -387,7 +393,7 @@ function SearchResults({
               //   Indicate whether this is selected
               aria-selected={selectedIndex === index}
               //   Provide a clean label for screen readers
-              aria-label={getResultAriaLabel(result)}
+              aria-label={ariaLabel}
               // Allow for nested-highlighting
               className="myst-search-result-item group"
               // Trigger selection on movement, so that scrolling doesn't trigger handler

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -207,28 +207,6 @@ function SearchShortcut() {
 }
 
 /**
- * Build a screen-reader-friendly label for a search result: page name first, then match context.
- */
-function getResultAriaLabel(result: RankedSearchResult): string {
-  const pageName = result.hierarchy.lvl1 ?? '';
-  // For top-level page matches, the page name itself is the match and there isn't extra content
-  if (result.type === 'lvl1') return pageName;
-  // For sub-page matches, include the matched heading or content snippet after the page name
-  let matchText =
-    result.type === 'content' ? result.content : result.hierarchy[result.type as HeadingLevel];
-  // Collapse whitespace and truncate long content so screen readers don't read entire paragraphs
-  if (matchText) {
-    matchText = matchText.replace(/\s+/g, ' ').trim();
-    if (matchText.length > 120) {
-      matchText = matchText.slice(0, 120) + '…';
-    }
-    return `${pageName} - ${matchText}`;
-  } else {
-    return pageName;
-  }
-}
-
-/**
  * Renderer for a single search result
  */
 function SearchResultItem({
@@ -286,8 +264,6 @@ function SearchResultItem({
       to={withBaseurl(url, baseurl)}
       // Close the main search on click
       onClick={closeSearch}
-      // There's an aria-label on the parent <li> so we hide the links
-      aria-hidden="true"
     >
       <div className="flex flex-row h-11">
         {iconRenderer}
@@ -361,15 +337,9 @@ function SearchResults({
     },
     [onHoverSelect],
   );
-  const searchResultsWithAria = useMemo(() => {
-    return searchResults.map((result) => {
-      const ariaLabel = getResultAriaLabel(result);
-      return { result, ariaLabel };
-    });
-  }, [searchResults]);
   return (
     <div className="myst-search-results mt-4 overflow-y-scroll">
-      {searchResultsWithAria.length ? (
+      {searchResults.length ? (
         <ul
           // Accessiblity:
           // indicate that this is a selectbox
@@ -382,7 +352,7 @@ function SearchResults({
           aria-activedescendant={activeDescendent}
           className={classNames('flex flex-col gap-y-2 px-1', className)}
         >
-          {searchResultsWithAria.map(({ result, ariaLabel }, index) => (
+          {searchResults.map((result, index) => (
             <li
               key={result.id}
               ref={setItemRef}
@@ -392,8 +362,6 @@ function SearchResults({
               role="option"
               //   Indicate whether this is selected
               aria-selected={selectedIndex === index}
-              //   Provide a clean label for screen readers
-              aria-label={ariaLabel}
               // Allow for nested-highlighting
               className="myst-search-result-item group"
               // Trigger selection on movement, so that scrolling doesn't trigger handler

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -207,6 +207,22 @@ function SearchShortcut() {
 }
 
 /**
+ * Build a screen-reader-friendly label for a search result: page name first, then match context.
+ * Visually we truncate the text but for screen readers we're providing it all.
+ * TODO: Validate the assumption that it's better to just provide all the text for screen readers!
+ */
+function getResultAriaLabel(result: RankedSearchResult): string {
+  const pageName = result.hierarchy.lvl1 ?? '';
+  // For top-level page matches, the page name itself is the match — no extra context needed
+  if (result.type === 'lvl1') return pageName;
+  // For sub-page matches, include the matched heading or content snippet after the page name
+  const matchText =
+    result.type === 'content' ? result.content : result.hierarchy[result.type as HeadingLevel];
+  // It's not clear if matchText will *always* exist but adding this conditional just in case
+  return matchText ? `${pageName} - ${matchText}` : pageName;
+}
+
+/**
  * Renderer for a single search result
  */
 function SearchResultItem({
@@ -264,6 +280,8 @@ function SearchResultItem({
       to={withBaseurl(url, baseurl)}
       // Close the main search on click
       onClick={closeSearch}
+      // There's an aria-label on the parent <li> so we hide the links
+      aria-hidden="true"
     >
       <div className="flex flex-row h-11">
         {iconRenderer}
@@ -362,6 +380,8 @@ function SearchResults({
               role="option"
               //   Indicate whether this is selected
               aria-selected={selectedIndex === index}
+              //   Provide a clean label for screen readers
+              aria-label={getResultAriaLabel(result)}
               // Allow for nested-highlighting
               className="myst-search-result-item group"
               // Trigger selection on movement, so that scrolling doesn't trigger handler
@@ -525,8 +545,10 @@ function SearchForm({
               { 'border-red-500': !enabled },
             )}
             id={searchInputID}
+            role="combobox"
             aria-labelledby={searchLabelID}
             aria-controls={searchListID}
+            aria-expanded={!!searchResults}
             placeholder="Search"
             type="search"
             required

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -267,13 +267,13 @@ function SearchResultItem({
     />
   );
 
-  // Render the subtitle i.e. file name
-  let subtitleRenderer;
+  // Render the context i.e. file name
+  let contextRenderer;
   if (result.type === 'lvl1') {
-    subtitleRenderer = undefined;
+    contextRenderer = undefined;
   } else {
-    const subtitle = result.hierarchy.lvl1!;
-    subtitleRenderer = <MarkedText text={subtitle} matches={matches} className="text-xs" />;
+    const contextName = result.hierarchy.lvl1!;
+    contextRenderer = <MarkedText text={contextName} matches={matches} className="text-xs" />;
   }
 
   const enterIconRenderer = (
@@ -292,8 +292,8 @@ function SearchResultItem({
       <div className="flex flex-row h-11">
         {iconRenderer}
         <div className="flex flex-col justify-center truncate grow">
+          {contextRenderer}
           {titleRenderer}
-          {subtitleRenderer}
         </div>
         {enterIconRenderer}
       </div>

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -221,8 +221,8 @@ function getResultAriaLabel(result: RankedSearchResult): string {
     matchText = matchText.replace(/\s+/g, ' ').trim();
     if (matchText.length > 120) {
       matchText = matchText.slice(0, 120) + '…';
-    };
-    return`${pageName} - ${matchText}`;
+    }
+    return `${pageName} - ${matchText}`;
   } else {
     return pageName;
   }

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -208,18 +208,24 @@ function SearchShortcut() {
 
 /**
  * Build a screen-reader-friendly label for a search result: page name first, then match context.
- * Visually we truncate the text but for screen readers we're providing it all.
- * TODO: Validate the assumption that it's better to just provide all the text for screen readers!
  */
 function getResultAriaLabel(result: RankedSearchResult): string {
   const pageName = result.hierarchy.lvl1 ?? '';
   // For top-level page matches, the page name itself is the match — no extra context needed
   if (result.type === 'lvl1') return pageName;
   // For sub-page matches, include the matched heading or content snippet after the page name
-  const matchText =
+  let matchText =
     result.type === 'content' ? result.content : result.hierarchy[result.type as HeadingLevel];
-  // It's not clear if matchText will *always* exist but adding this conditional just in case
-  return matchText ? `${pageName} - ${matchText}` : pageName;
+  // Collapse whitespace and truncate long content so screen readers don't read entire paragraphs
+  if (matchText) {
+    matchText = matchText.replace(/\s+/g, ' ').trim();
+    if (matchText.length > 120) {
+      matchText = matchText.slice(0, 120) + '…';
+    };
+    return`${pageName} - ${matchText}`;
+  } else {
+    return pageName;
+  }
 }
 
 /**

--- a/packages/site/src/components/Navigation/Search.tsx
+++ b/packages/site/src/components/Navigation/Search.tsx
@@ -211,7 +211,7 @@ function SearchShortcut() {
  */
 function getResultAriaLabel(result: RankedSearchResult): string {
   const pageName = result.hierarchy.lvl1 ?? '';
-  // For top-level page matches, the page name itself is the match — no extra context needed
+  // For top-level page matches, the page name itself is the match and there isn't extra content
   if (result.type === 'lvl1') return pageName;
   // For sub-page matches, include the matched heading or content snippet after the page name
   let matchText =


### PR DESCRIPTION
This adds some aria metadata to our search results in the hopes that it makes it a bit more screen-reader-friendly. This is not my expertise, but these seemed like straightforward things to improve the UX a bit for screen readers!

Major things to note:

- `aria-label` is now explicitly set (though cut-off at 120 characters since some of the descriptions were super long)
- the `<a>` below now has `aria-hidden`, which I think means that screen readers will just focus on the `li` instead of the underlying `a`, and the label should give the useful text we need
- In other parts i added a `role` which I think should make it stop reading like a big blob of text

Here's what each item spits out.

```html
<li data-index="2" role="option" aria-selected="true" aria-label="Long Content - This document demonstrates how the theme handles long-form content. It includes multiple sections, subsections, and vari…" class="myst-search-result-item group">
  <a class="block px-1 py-2 text-gray-700 rounded shadow-md dark:text-white group-aria-selected:bg-blue-600 group-aria-selected:text-white dark:shadow-none dark:bg-stone-800" aria-hidden="true" href="/reference/really-long#introduction">
     [unchanged stuff inside]
  </a>
</li>
```

It would be really helpful if a person that has a screen reader could test this out and give any pointers - I don't have a ton of cycles to put into this, but am happy to iterate a bit if it can give an incremental improvement! cc @JimMadge and @LizHareDogs maybe?

### To test this

- Go to the docs preview here: [Docs preview](https://deploy-preview-854--myst-theme.netlify.app/)
- Click the search bar or click `cmd+K`
- Type something, scroll through search results, report back if they are useful on screen readers!

---

- closes https://github.com/jupyter-book/myst-theme/issues/823 (somebody please tell me if it does not!)