### PR TITLE
Fix equations scrollable 

### DIFF
--- a/.changeset/ripe-taxis-find.md
+++ b/.changeset/ripe-taxis-find.md
@@ -1,0 +1,5 @@
+---
+'myst-to-react': patch
+---
+
+Add tabindex when equations overflow

--- a/docs/reference/typography.md
+++ b/docs/reference/typography.md
@@ -106,7 +106,13 @@ $$
 $$
 
 $$
-\frac{d}{dx} \left( \int_{0}^{x} f(u) du \right) = f(x)
+\begin{align*}
+P(\text{Third Year} ~\Big\vert~ \text{Declared}) 
+~ &=~ \frac{ 0.4 \times 0.8}{0.6 \times 0.5 ~+~ 0.4 \times  0.8} \\ \\
+&=~ \frac{\text{(prior probability of Third Year)} \times
+\text{(likelihood of Declared given Third Year)}}
+{\text{total probability of Declared}}
+\end{align*}
 $$
 
 ## Special Characters

--- a/packages/myst-to-react/src/math.tsx
+++ b/packages/myst-to-react/src/math.tsx
@@ -59,7 +59,13 @@ const mathRenderer: NodeRenderer<MathLike> = ({ node, className }) => {
           ref={ref}
           tabIndex={isScrollable ? 0 : undefined}
           role={isScrollable ? 'region' : undefined}
-          aria-label={isScrollable ? (node.enumerator ? `Equation ${node.enumerator}` : 'Mathematical Equation') : undefined}
+          aria-label={
+            isScrollable
+              ? node.enumerator
+                ? `Equation ${node.enumerator}`
+                : 'Mathematical Equation'
+              : undefined
+          }
           dangerouslySetInnerHTML={{ __html: node.html }}
           className="flex-grow overflow-x-auto overflow-y-hidden"
         />

--- a/packages/myst-to-react/src/math.tsx
+++ b/packages/myst-to-react/src/math.tsx
@@ -3,6 +3,7 @@ import type { InlineMath, Math } from 'myst-spec';
 import { InlineError } from './inlineError.js';
 import { HashLink } from './hashLink.js';
 import type { NodeRenderer } from '@myst-theme/providers';
+import { useIsScrollable } from '@myst-theme/providers';
 import classNames from 'classnames';
 
 // function Math({ value, html }: { value: string; html: string }) {
@@ -37,6 +38,7 @@ type MathLike = (InlineMath | Math) & {
 };
 
 const mathRenderer: NodeRenderer<MathLike> = ({ node, className }) => {
+  const { ref, isScrollable } = useIsScrollable<HTMLDivElement>();
   if (node.type === 'math') {
     if (node.error || !node.html) {
       return (
@@ -54,6 +56,10 @@ const mathRenderer: NodeRenderer<MathLike> = ({ node, className }) => {
     return (
       <div id={id} className={classNames('flex my-5 group', className)}>
         <div
+          ref={ref}
+          tabIndex={isScrollable ? 0 : undefined}
+          role={isScrollable ? 'region' : undefined}
+          aria-label={isScrollable ? (node.enumerator ? `Equation ${node.enumerator}` : 'Mathematical Equation') : undefined}
           dangerouslySetInnerHTML={{ __html: node.html }}
           className="flex-grow overflow-x-auto overflow-y-hidden"
         />


### PR DESCRIPTION
Closes #858 

This PR replaces an example of display math with a wide (scrollable) one and implements the accessibility fix `tabindex="0"` following what Chris did in #852.

This PR and associated issue are part of the ongoing work in https://github.com/jupyter-book/mystmd/issues/2802