### PR TITLE
Allow navbar to grow in height

### DIFF
--- a/.changeset/itchy-frogs-remember.md
+++ b/.changeset/itchy-frogs-remember.md
@@ -1,0 +1,5 @@
+---
+"@myst-theme/site": patch
+---
+
+Allow navbar to grow in height

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -46,6 +46,14 @@ site:
   nav:
     - title: Developer page
       url: /developer
+    - title: Resources
+      children:
+        - title: MyST documentation
+          url: https://mystmd.org
+        - title: GitHub repository
+          url: https://github.com/jupyter-book/myst-theme
+        - title: Reference
+          url: /reference
   options:
     site_title: myst-theme documentation
     folders: true

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -5,3 +5,7 @@ title: Visual Reference
 This section provides a gallery of the components commonly used to construct a MyST document.
 
 You can try these components for yourself in the [sandbox](https://mystmd.org/sandbox).
+
+:::{tableofcontents}
+:kind: children
+:::

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -29,6 +29,27 @@ site:
     logo_alt: alternative text for the site logo
 ```
 
+### Navigation items
+
+Add links to the top navigation bar with `site.nav`. Each entry is either a single link or a group of links rendered as a dropdown menu. When a nav item has a `children` list, it renders as a dropdown.
+
+```{code-block} yaml
+:filename: myst.yml
+
+site:
+  nav:
+    - title: Developer page
+      url: /developer
+    - title: Resources
+      children:
+        - title: MyST documentation
+          url: https://mystmd.org
+        - title: GitHub repository
+          url: https://github.com/jupyter-book/myst-theme
+        - title: Reference
+          url: /reference
+```
+
 ## Banner
 
 Display an announcement bar at the top of your site.

--- a/packages/site/src/components/Navigation/ThemeButton.tsx
+++ b/packages/site/src/components/Navigation/ThemeButton.tsx
@@ -1,6 +1,5 @@
 import { useThemeSwitcher } from '@myst-theme/providers';
-import { MoonIcon } from '@heroicons/react/24/solid';
-import { SunIcon } from '@heroicons/react/24/outline';
+import { MoonIcon, SunIcon } from '@heroicons/react/24/solid';
 import classNames from 'classnames';
 
 export function ThemeButton({ className = 'w-10 h-10 mx-3' }: { className?: string }) {
@@ -8,15 +7,15 @@ export function ThemeButton({ className = 'w-10 h-10 mx-3' }: { className?: stri
   return (
     <button
       className={classNames(
-        'myst-theme-button theme rounded-full aspect-square border border-stone-700 dark:border-white hover:bg-neutral-100 border-solid overflow-hidden text-stone-700 dark:text-white hover:text-stone-500 dark:hover:text-neutral-800',
+        'myst-theme-button theme shrink-0 rounded-full border border-stone-700 dark:border-white hover:bg-neutral-100 border-solid overflow-hidden text-stone-700 dark:text-white hover:text-stone-500 dark:hover:text-neutral-800',
         className,
       )}
       title={`Toggle theme between light and dark mode`}
       aria-label={`Toggle theme between light and dark mode`}
       onClick={nextTheme}
     >
-      <MoonIcon className="myst-theme-moon-icon h-full w-full p-0.5 hidden dark:block" />
-      <SunIcon className="myst-theme-sun-icon h-full w-full p-0.5 dark:hidden" />
+      <MoonIcon className="myst-theme-moon-icon h-full w-full p-[18%] hidden dark:block" />
+      <SunIcon className="myst-theme-sun-icon h-full w-full p-[18%] dark:hidden" />
     </button>
   );
 }

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -169,7 +169,7 @@ export function TopNav({
           {/* Search bar */}
           {!hideSearch && <Search />}
           {/* Light/Dark theme button */}
-          <ThemeButton className="w-10 h-10 ml-3" />
+          <ThemeButton className="w-8 h-8 ml-3" />
           {/* Custom part at end of navbar. It is `hidden` up until xl size since it will be in the sidebar drawer up to that point */}
           {navbarEnd && (
             <div className="article myst-navbar-end hidden xl:flex items-center ml-3 [&>*]:m-0">

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -128,8 +128,12 @@ export function TopNav({
   const config = useSiteManifest();
   const { title, nav, actions } = config ?? {};
   const { logo, logo_dark, logo_text, logo_url, logo_alt } = config?.options ?? {};
+  // TODO: when the nav wraps to multiple lines the header grows past 60px, but
+  //   there are downstream consumers of DEFAULT_NAV_HEIGHT and this will
+  //   cause a mismatch if the navbar grows. Here we set it to `min-h` to let
+  //   it grow, but we'll need to revisit downstream height consumers eventually.
   return (
-    <div className="myst-top-nav bg-white/80 backdrop-blur dark:bg-stone-900/80 shadow dark:shadow-stone-700 p-3 md:px-8 sticky w-full top-0 z-30 h-[60px]">
+    <div className="myst-top-nav bg-white/80 backdrop-blur dark:bg-stone-900/80 shadow dark:shadow-stone-700 p-3 md:px-8 sticky w-full top-0 z-30 min-h-[60px]">
       <nav className="myst-top-nav-bar flex items-center justify-between flex-nowrap max-w-[1440px] mx-auto">
         <div className="flex flex-row xl:min-w-[19.5rem] mr-2 sm:mr-7 justify-start items-center shrink-0">
           {


### PR DESCRIPTION
This sets the height of the navbar to `min-h-` instead of `h-` so that it can grow if the content inside grows. It also gives it a bit more padding and makes sure it doesn't get squeezed if the navbar grows.

This doesn't totally fix the problem of content overflow, because some downstream stuff still assumes that the header height is a fixed amount. So I added a comment w/ a TODO for what we'll need to do eventually just to avoid blocking this incremental bugfix.

With this PR (an extreme example to show the navbar grows and the buttons look their normal size):

<img width="2276" height="416" alt="CleanShot 2026-04-27 at 09 49 04@2x" src="https://github.com/user-attachments/assets/f6e75358-17d3-4f17-bdc3-16dc94ca98b2" />

---

- closes #862 