### PR TITLE
Add not-prose to active thebe case

### DIFF
--- a/.changeset/red-tables-vanish.md
+++ b/.changeset/red-tables-vanish.md
@@ -1,0 +1,5 @@
+---
+"@myst-theme/jupyter": patch
+---
+
+Add not-prose to active thebe case

--- a/packages/jupyter/src/active.tsx
+++ b/packages/jupyter/src/active.tsx
@@ -56,7 +56,9 @@ export function ActiveOutputRenderer({
       <div
         ref={ref}
         data-thebe-active-ref="true"
-        className={classNames('relative', { 'invisible h-0': !executed && placeholder })}
+        className={classNames('relative not-prose', {
+          'invisible h-0': !executed && placeholder,
+        })}
       />
       {exec.ready && placeholder && !executed && <MyST ast={placeholder} />}
     </div>


### PR DESCRIPTION
This adds a `.not-prose` class to the thebe cell outputs when we have a live kernel. It already exists in the "not yet executed" condition but executing a cell changes the parent wrapper and removes the `.not-prose`, thus we need to manually add it here.

---

- closes https://github.com/jupyter-book/jupyter-book/issues/2614