### PR TITLE
Fix vertical height for stacked buttons

### DIFF
--- a/.changeset/bright-hairs-provide.md
+++ b/.changeset/bright-hairs-provide.md
@@ -1,0 +1,5 @@
+---
+"@myst-theme/styles": patch
+---
+
+Fix vertical height for stacked buttons

--- a/docs/reference/typography.md
+++ b/docs/reference/typography.md
@@ -87,6 +87,12 @@ The {smallcaps}`HTML` specification defines web standards.
 
 {button}`Click Me! <https://mystmd.org>`
 
+Button inline {button}`Click Me! <https://mystmd.org>`.
+
+Lots of horizontally stacked buttons to show how they spill onto lines.
+
+{button}`Button one <https://example.com>` {button}`Button two with really long text <https://example.com>` {button}`Button three with really long text <https://example.com>` {button}`Button four <https://example.com>` {button}`Button five <https://example.com>`
+
 (math)=
 
 ## Math

--- a/docs/reference/typography.md
+++ b/docs/reference/typography.md
@@ -89,6 +89,12 @@ The {smallcaps}`HTML` specification defines web standards.
 
 Button inline {button}`Click Me! <https://mystmd.org>`.
 
+Long paragraph of text with a button after at least one line break has happened.
+Long paragraph of text with a button after at least one line break has happened.
+Button inline {button}`Click Me! <https://mystmd.org>`.
+Long paragraph of text with a button after at least one line break has happened.
+Long paragraph of text with a button after at least one line break has happened.
+
 Lots of horizontally stacked buttons to show how they spill onto lines.
 
 {button}`Button one <https://example.com>` {button}`Button two with really long text <https://example.com>` {button}`Button three with really long text <https://example.com>` {button}`Button four <https://example.com>` {button}`Button five <https://example.com>`

--- a/styles/button.css
+++ b/styles/button.css
@@ -4,7 +4,7 @@
   button.button,
   span.button,
   cite.button a {
-    @apply inline-block m-1 px-4 py-2 font-bold rounded no-underline cursor-pointer;
+    @apply inline-block mt-1 px-4 py-1 font-bold rounded no-underline cursor-pointer;
     @apply text-white dark:text-white hover:text-white dark:hover:text-white;
     @apply bg-blue-500 whitespace-nowrap;
     &:hover {

--- a/styles/button.css
+++ b/styles/button.css
@@ -4,7 +4,7 @@
   button.button,
   span.button,
   cite.button a {
-    @apply px-4 py-2 font-bold rounded no-underline cursor-pointer;
+    @apply inline-block m-1 px-4 py-2 font-bold rounded no-underline cursor-pointer;
     @apply text-white dark:text-white hover:text-white dark:hover:text-white;
     @apply bg-blue-500 whitespace-nowrap;
     &:hover {


### PR DESCRIPTION
Sets button `role` items to be inline-block so that their height is respected for the line they're on, and gives a consistent margin so they stack / are spaced consistently.

There's a trade-off here, which is that moving to `inline-block` means that the button will create extra whitespace if it's used with inline text (see before/after below). It feels like a reasonable trade-off since this is really a "UI component" not a piece of text. I'm curious if others disagree though!


| Before | After |
|--------|-------|
| <img width="1472" height="1326" alt="CleanShot 2026-05-10 at 15 42 49@2x" src="https://github.com/user-attachments/assets/14ee5355-d9ce-4fa0-a03c-6362c6e80589" /> | <img width="1472" height="1326" alt="CleanShot 2026-05-10 at 15 42 54@2x" src="https://github.com/user-attachments/assets/91db6bd0-d7cb-4182-9b69-4ae6ba5a0145" /> |

---

- closes #871 