### PR TITLE
Do not override logo background color in dark mode

### DIFF
--- a/packages/site/src/components/Navigation/HomeLink.tsx
+++ b/packages/site/src/components/Navigation/HomeLink.tsx
@@ -29,7 +29,7 @@ export function HomeLink({
       {logo && (
         <div
           className={classNames('myst-home-link-logo mr-3 flex items-center', {
-            'dark:bg-white dark:rounded px-1': !logoDark,
+            'dark:rounded px-1': !logoDark,
           })}
         >
           <img


### PR DESCRIPTION
This prevents a single transparent SVG from being used as a logo. Instead, I will provide a matching PR in the mystmd docs that show how to use `logo` and `logo_dark` together.