### PR TITLE
Support dark mode with mermaid diagrams

### DIFF
--- a/.changeset/mermaid-dark-mode.md
+++ b/.changeset/mermaid-dark-mode.md
@@ -1,0 +1,5 @@
+---
+'@myst-theme/diagrams': patch
+---
+
+Mermaid diagrams now respect the active light/dark theme and re-render when the user toggles theme.

--- a/packages/diagrams/src/index.tsx
+++ b/packages/diagrams/src/index.tsx
@@ -1,4 +1,4 @@
-import type { NodeRenderer } from '@myst-theme/providers';
+import { useThemeSwitcher, type NodeRenderer } from '@myst-theme/providers';
 import { useEffect, useId, useState } from 'react';
 import classNames from 'classnames';
 import type { Mermaid } from 'mermaid';
@@ -9,7 +9,6 @@ async function loadMermaid(): Promise<Mermaid> {
   if (_mermaid === undefined) {
     const module = await import('mermaid');
     _mermaid = module.default;
-    _mermaid.initialize({ startOnLoad: false });
   }
   return _mermaid;
 }
@@ -24,6 +23,7 @@ export function MermaidRenderer({
   className?: string;
 }) {
   const key = useId();
+  const { isDark } = useThemeSwitcher();
   const [graph, setGraph] = useState<string>();
   const [error, setError] = useState<Error>();
   useEffect(() => {
@@ -31,6 +31,7 @@ export function MermaidRenderer({
       try {
         const mermaidID = `mermaid-${key.replace(/:/g, '')}`;
         const mermaid = await loadMermaid();
+        mermaid.initialize({ startOnLoad: false, theme: isDark ? 'dark' : 'default' });
         const { svg } = await mermaid.render(mermaidID, value);
         setGraph(svg);
         setError(undefined);
@@ -40,7 +41,7 @@ export function MermaidRenderer({
       }
     };
     render();
-  }, []);
+  }, [isDark]);
   return (
     <figure id={id} className={className}>
       {graph && <div dangerouslySetInnerHTML={{ __html: graph }}></div>}


### PR DESCRIPTION
This attaches a hook to the theme switcher and re-renders mermaid diagrams accordingly when the theme is dark

Here's how it looks in the preview (see linked issue for 'before' version):

<img width="1326" height="580" alt="CleanShot 2026-05-23 at 15 00 20@2x" src="https://github.com/user-attachments/assets/78d1b088-1901-49de-8009-10de67e67f18" />

---

- closes #880 