### PR TITLE
Syntax highlight TOML

### DIFF
--- a/.changeset/shaggy-ghosts-hide.md
+++ b/.changeset/shaggy-ghosts-hide.md
@@ -1,6 +1,6 @@
 ---
-'myst-to-react': minor
-'@myst-theme/site': minor
+'myst-to-react': patch
+'@myst-theme/site': patch
 ---
 
 Fix TOML highlighting

--- a/.changeset/shaggy-ghosts-hide.md
+++ b/.changeset/shaggy-ghosts-hide.md
@@ -1,0 +1,6 @@
+---
+'myst-to-react': minor
+'@myst-theme/site': minor
+---
+
+Fix TOML highlighting

--- a/packages/myst-to-react/src/code.tsx
+++ b/packages/myst-to-react/src/code.tsx
@@ -28,6 +28,8 @@ function normalizeLanguage(lang?: string): string | undefined {
   switch (lang) {
     case 'html':
       return 'xml';
+    case 'toml':
+      return 'ini';
     default:
       return lang;
   }


### PR DESCRIPTION
In highlight.js, TOML/ini are interchangeable

/cc @henryiii