### PR TITLE
Serve project static_files through the dev server

### DIFF
--- a/.changeset/two-animals-dress.md
+++ b/.changeset/two-animals-dress.md
@@ -1,0 +1,6 @@
+---
+'@myst-theme/article': patch
+'@myst-theme/book': patch
+---
+
+Serve static files by relaying past routing

--- a/themes/article/app/routes/$.tsx
+++ b/themes/article/app/routes/$.tsx
@@ -1,6 +1,7 @@
 import { getProject, isFlatSite, parsePathname, type PageLoader } from '@myst-theme/common';
 import {
   json,
+  redirect,
   type LinksFunction,
   type LoaderFunction,
   type V2_MetaFunction,
@@ -11,7 +12,7 @@ import {
   ErrorDocumentNotFound,
   ErrorUnhandled,
 } from '@myst-theme/site';
-import { getConfig, getPage } from '~/utils/loaders.server';
+import { getConfig, getPage, getStaticFileUrl } from '~/utils/loaders.server';
 import { useLoaderData } from '@remix-run/react';
 import type { SiteManifest } from 'myst-config';
 import { ArticlePageAndNavigation } from '../components/ArticlePageAndNavigation';
@@ -47,19 +48,29 @@ export const meta: V2_MetaFunction<typeof loader> = ({ data, matches, location }
 export const links: LinksFunction = () => [KatexCSS];
 
 export const loader: LoaderFunction = async ({ params, request }) => {
-  const [first, ...rest] = parsePathname(new URL(request.url).pathname);
+  const url = new URL(request.url);
+  const [first, ...rest] = parsePathname(url.pathname);
   const config = await getConfig();
   const project = getProject(config, first);
   const projectName = project?.slug === first ? first : undefined;
   const slugParts = projectName ? rest : [first, ...rest];
   const slug = slugParts.length ? slugParts.join('.') : undefined;
   const flat = isFlatSite(config);
-  const page = await getPage(request, {
-    project: flat ? projectName : (projectName ?? slug),
-    slug: flat ? slug : projectName ? slug : undefined,
-    redirect: process.env.MODE === 'static' ? false : true,
-  });
-  return json({ config, project, page });
+  try {
+    const page = await getPage(request, {
+      project: flat ? projectName : (projectName ?? slug),
+      slug: flat ? slug : projectName ? slug : undefined,
+      // MODE=static is set by mystmd when pre-rendering pages for `myst build --html`; skip index redirects in that case.
+      redirect: process.env.MODE === 'static' ? false : true,
+    });
+    return json({ config, project, page });
+  } catch (e) {
+    if (e instanceof Response && e.status === 404) {
+      const cdnUrl = await getStaticFileUrl(url.pathname);
+      if (cdnUrl) throw redirect(cdnUrl);
+    }
+    throw e;
+  }
 };
 
 export default function Page() {

--- a/themes/article/app/utils/loaders.server.ts
+++ b/themes/article/app/utils/loaders.server.ts
@@ -95,6 +95,17 @@ export async function getPage(
   return { ...loader, footer, domain: getDomainFromRequest(request), project: projectName };
 }
 
+/**
+ * Return the content CDN URL for a path if it exists as a static file,
+ * or null if the content server has no such file.
+ */
+export async function getStaticFileUrl(pathname: string): Promise<string | null> {
+  const url = `${CONTENT_CDN}${pathname}`;
+  const response = await fetch(url, { method: 'HEAD' }).catch(() => null);
+  if (!response || !response.ok) return null;
+  return url;
+}
+
 export async function getObjectsInv(): Promise<Buffer | null> {
   const url = updateLink('/objects.inv');
   const response = await fetch(url).catch(() => null);

--- a/themes/book/app/routes/$.tsx
+++ b/themes/book/app/routes/$.tsx
@@ -1,5 +1,6 @@
 import {
   json,
+  redirect,
   type V2_MetaFunction,
   type LinksFunction,
   type LoaderFunction,
@@ -15,7 +16,7 @@ import {
   ErrorDocumentNotFound,
   ErrorUnhandled,
 } from '@myst-theme/site';
-import { getConfig, getPage } from '~/utils/loaders.server';
+import { getConfig, getPage, getStaticFileUrl } from '~/utils/loaders.server';
 import { useLoaderData } from '@remix-run/react';
 import type { SiteManifest } from 'myst-config';
 import {
@@ -63,19 +64,29 @@ export const meta: V2_MetaFunction<typeof loader> = ({ data, matches, location }
 export const links: LinksFunction = () => [KatexCSS];
 
 export const loader: LoaderFunction = async ({ params, request }) => {
-  const [first, ...rest] = parsePathname(new URL(request.url).pathname);
+  const url = new URL(request.url);
+  const [first, ...rest] = parsePathname(url.pathname);
   const config = await getConfig();
   const project = getProject(config, first);
   const projectName = project?.slug === first ? first : undefined;
   const slugParts = projectName ? rest : [first, ...rest];
   const slug = slugParts.length ? slugParts.join('.') : undefined;
   const flat = isFlatSite(config);
-  const page = await getPage(request, {
-    project: flat ? projectName : (projectName ?? slug),
-    slug: flat ? slug : projectName ? slug : undefined,
-    redirect: process.env.MODE === 'static' ? false : true,
-  });
-  return json({ config, page, project });
+  try {
+    const page = await getPage(request, {
+      project: flat ? projectName : (projectName ?? slug),
+      slug: flat ? slug : projectName ? slug : undefined,
+      // MODE=static is set by mystmd when pre-rendering pages for `myst build --html`; skip index redirects in that case.
+      redirect: process.env.MODE === 'static' ? false : true,
+    });
+    return json({ config, page, project });
+  } catch (e) {
+    if (e instanceof Response && e.status === 404) {
+      const cdnUrl = await getStaticFileUrl(url.pathname);
+      if (cdnUrl) throw redirect(cdnUrl);
+    }
+    throw e;
+  }
 };
 
 function ArticlePageAndNavigationInternal({

--- a/themes/book/app/utils/loaders.server.ts
+++ b/themes/book/app/utils/loaders.server.ts
@@ -96,6 +96,17 @@ export async function getPage(
   return { ...loader, footer, domain: getDomainFromRequest(request), project: projectName };
 }
 
+/**
+ * Return the content CDN URL for a path if it exists as a static file,
+ * or null if the content server has no such file.
+ */
+export async function getStaticFileUrl(pathname: string): Promise<string | null> {
+  const url = `${CONTENT_CDN}${pathname}`;
+  const response = await fetch(url, { method: 'HEAD' }).catch(() => null);
+  if (!response || !response.ok) return null;
+  return url;
+}
+
 export async function getObjectsInv(): Promise<Buffer | null> {
   const url = updateLink('/objects.inv');
   const response = await fetch(url).catch(() => null);


### PR DESCRIPTION
This is an accompanying PR to https://github.com/jupyter-book/mystmd/pull/2770 addressing https://github.com/jupyter-book/mystmd/issues/2863#issuecomment-4568065834

https://github.com/jupyter-book/mystmd/pull/2770 adds static files to the build, but the theme needs to know about them: otherwise, when you hit a non-existent page, it gives up.

With this PR: when the catch-all route finds no MyST page for a path, probe the content server (HEAD request) to check whether the path exists as a static file. If so, redirect to the content CDN URL.

Remix then handles redirect responses correctly for both document and data requests. For a static file, the browser follows the redirect and the file is served directly by the Express content server, which mounts session.publicPath() at /.

Seeing MODE=static in the code confused me, so to clarify: that is pre-existing to this PR, and it is set by us (not a Remix/Node convention). When pre-rendering pages for `myst build --html`, it is used to suppress index redirects during static builds.