### PR TITLE
Add a @main workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,3 +99,14 @@ jobs:
     with:
       tag_name: ${{ needs.get-tag.outputs.tag_name }}
     secrets: inherit
+
+  # Refresh the rolling `myst-to-react@main` prerelease on every push to main,
+  # so power users can pin their themes to the bleeding edge. Runs regardless of
+  # whether a version was published. See README "Track the latest main".
+  refresh-main-assets:
+    name: Refresh myst-to-react@main assets
+    uses: ./.github/workflows/theme-assets.yml
+    with:
+      tag_name: myst-to-react@main
+      rolling: true
+    secrets: inherit

--- a/.github/workflows/theme-assets.yml
+++ b/.github/workflows/theme-assets.yml
@@ -18,6 +18,8 @@ name: Publish theme assets to GitHub Release
 #     attaching the zips to the GitHub release it created for that tag. (The release
 #     event below does not fire there, because releases created with GITHUB_TOKEN do
 #     not trigger further workflow runs, so release.yml calls this explicitly.)
+#   - called by release.yml on every push to main, with rolling=true, to refresh
+#     the bleeding-edge `myst-to-react@main` prerelease.
 #   - creating a GitHub release (UI / CLI / API), which also works on forks
 #     (manual / custom builds).
 on:
@@ -26,6 +28,12 @@ on:
       tag_name:
         required: true
         type: string
+      # When true, refresh a single prerelease in place (overwriting its assets)
+      # instead of attaching to a fixed release. Used for the rolling main release.
+      rolling:
+        required: false
+        type: boolean
+        default: false
   release:
     types: [published]
 
@@ -75,9 +83,28 @@ jobs:
       # tag that triggered the workflow. If the release already exists (the
       # changesets path), the action updates it and keeps its notes.
       - name: Upload release assets
+        if: ${{ !inputs.rolling }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag_name || github.ref_name }}
           files: dist_zip/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Update myst-to-react@main with the latest changes. We create the
+      # prerelease once and then overwrite its assets in place on later pushes.
+      # Note that the tag will not change, so it'll technically point to a different
+      # state of the repo, so we also add the hash of the latest update to the notes.
+      - name: Refresh rolling release
+        if: ${{ inputs.rolling }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ inputs.tag_name }}"
+          NOTES="Bleeding-edge theme assets, rebuilt from \`main\` on each push (currently $GITHUB_SHA). Use at your own risk! This tracks unreleased changes and can break at any time."
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist_zip/*.zip --clobber
+            gh release edit "$TAG" --notes "$NOTES"
+          else
+            gh release create "$TAG" --title "$TAG" --notes "$NOTES" --prerelease --target "$GITHUB_SHA" dist_zip/*.zip
+          fi

--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ site:
     https://github.com/my-orga/myst-theme/releases/download/my-release/book-theme.zip
 ```
 
+### Track the latest `main`
+
+Every push to `main` refreshes a rolling `myst-to-react@main` prerelease with freshly built theme zips, via the `release.yml` workflow.
+This lets you try unreleased changes by pinning your theme to it:
+
+```yaml
+site:
+  template: https://github.com/jupyter-book/myst-theme/releases/download/myst-to-react@main/book-theme.zip
+```
+
+Use at your own risk! This tracks unreleased work and can break at any time.
+It is meant for power users who want to test bleeding-edge changes and report regressions early.
+
 ### Browse available versions
 
 Published versions of the `article` and `book` themes can be found [![as GH releases](https://img.shields.io/badge/as%20GH%20releases-blue?logo=github&style=flat-square)](https://github.com/jupyter-book/myst-theme/releases)


### PR DESCRIPTION
Follow-up from the collab cafe discussion. This adds an extra branch to our "release assets" workflow that updates a `myst-to-react@main` release with newly-built assets. It runs on each commit to main, so the assets are re-built each time we merge.

Similar to the PR we just merged, I'm not sure how to test this out other than to just merge it and see if it works. Any objections?

---

- closes #890 