### PR TITLE
Fix a11y check workflow

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   check-a11y:
     runs-on: ubuntu-latest
+    # Allow the workflow to create/update the accessibility audit issue
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
 
@@ -22,7 +26,9 @@ jobs:
           npm run build
           make build-book
 
+      # Don't fail the job when violations are found; we report them via the issue below
       - name: Run Accessibility Checks
+        continue-on-error: true
         uses: berkeley-cdss/myst-a11y@v1
         with:
           working_directory: 'docs'

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -49,3 +49,12 @@ For example, see the `myst-to-react` configuration:
     "test": "vitest run",
     ...
 ```
+
+(testing:a11y)=
+## Accessibility audit
+
+On every push to `main`, the [`a11y.yml` workflow](https://github.com/jupyter-book/myst-theme/blob/main/.github/workflows/a11y.yml) builds the documentation against the local theme and runs an [axe-core](https://github.com/dequelabs/axe-core) accessibility audit via [`berkeley-cdss/myst-a11y`](https://github.com/berkeley-cdss/myst-a11y).
+
+If violations are found, the results are reported in a GitHub issue labelled [`a11y-audit`](https://github.com/jupyter-book/myst-theme/issues?q=label%3Aa11y-audit).
+
+To see the current state of accessibility issues, look for the open `a11y-audit` issue.


### PR DESCRIPTION
This does a few follow-ups:

- Documents the a11y-check workflow
- Makes it not "error" if a11y problems are found, instead it just opens the issue
- Adds permissions so that it can edit issues