### PR TITLE
Demonstrate bug by setting Jupyter to false

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -19,7 +19,7 @@ project:
     - rule: link-resolves
       keys:
         - 'https://github.com/**'
-  jupyter: true
+  jupyter: false
   parts:
     banner: |
       📢 **Announcement:** This is a test banner for the MyST Theme! [Learn more about MyST](/reference).


### PR DESCRIPTION
If https://github.com/jupyter-book/mystmd/issues/2901 is correct then this PR should make outputs stop rendering in the preview docs

[This PR, interactive outputs are broken](https://deploy-preview-899--myst-theme.netlify.app/reference/computation/)

[On main, interactive outputs work (bc jupyter: true)](https://myst-theme.netlify.app/reference/computation/)