### PR TITLE
fix: add text-myst-text to hover card surfaces

### DIFF
--- a/packages/myst-to-react/src/components/LinkCard.tsx
+++ b/packages/myst-to-react/src/components/LinkCard.tsx
@@ -9,7 +9,7 @@ export function LinkCard({
   loading = false,
   description,
   thumbnail,
-  className = 'w-[300px] sm:max-w-[500px] bg-myst-bg rounded shadow-md',
+  className = 'w-[300px] sm:max-w-[500px] bg-myst-bg rounded shadow-md text-myst-text',
 }: {
   url: string;
   internal?: boolean;

--- a/styles/hover.css
+++ b/styles/hover.css
@@ -34,7 +34,7 @@
   }
 
   .hover-document {
-    @apply text-sm bg-myst-bg dark:bg-myst-surface border rounded shadow-xl border-myst-border;
+    @apply text-sm bg-myst-bg dark:bg-myst-surface border rounded shadow-xl border-myst-border text-myst-text;
   }
 
   /* Hoverable links: dotted underline */


### PR DESCRIPTION
closes #908

a bolder change might be to set it on the entire body, but consequences for that are beyond what I think I know enough about