### PR TITLE
Use just system-ui for font

### DIFF
--- a/styles/index.js
+++ b/styles/index.js
@@ -72,6 +72,9 @@ const themeExtensions = {
     'myst-gray-bg': 'var(--myst-color-gray-bg)',
     'myst-gray-text': 'var(--myst-color-gray-text)',
   },
+  fontFamily: {
+    sans: ['var(--myst-font-sans)'],
+  },
   gridTemplateColumns: {
     'article-sm':
       '[screen-start screen-inset-start] 0.5rem [page-start page-inset-start body-outset-start body-start gutter-left-start body-inset-start middle-start] 1fr 1fr [gutter-left-end] 1fr 1fr [gutter-right-start] 1fr 1fr [middle-end body-inset-end body-end gutter-right-end body-outset-end page-inset-end page-end] 0.5rem [screen-inset-end screen-end]',

--- a/styles/theme-colors.css
+++ b/styles/theme-colors.css
@@ -79,6 +79,9 @@
     --myst-color-gray: #6b7280; /* gray-500 */
     --myst-color-gray-bg: #f9fafb; /* gray-50 */
     --myst-color-gray-text: #4b5563; /* gray-600 */
+
+    /* Prose font */
+    --myst-font-sans: system-ui, sans-serif;
   }
 
   .dark {


### PR DESCRIPTION
This defines an explicit font for prose, to see if it renders more nicely on ubuntu.

@mfisher87 want to test this out and see if it looks different? (see the netlify preview when it's done).

---

- closes #911 