### PR TITLE
Remove autoplay and add controls to the Video component

### DIFF
--- a/packages/myst-to-react/src/image.tsx
+++ b/packages/myst-to-react/src/image.tsx
@@ -56,7 +56,7 @@ function Video({
   align?: Alignment;
 }) {
   return (
-    <video
+    <video controls
       className={className}
       id={id}
       style={{
@@ -66,12 +66,6 @@ function Video({
       }}
       src={src}
       data-canonical-url={urlSource}
-      autoPlay
-      // For autoplay, the element needs to be muted to actually start!
-      muted
-      webkit-playsinline="true"
-      playsInline
-      loop
     />
   );
 }


### PR DESCRIPTION
This is firstly a temporary workaround for https://github.com/jupyter-book/mystmd/issues/2385 until a video directive is added that is addressed in the issue https://github.com/jupyter-book/mystmd/issues/532 .

However, I would wish that this PR is integrated until `prefers-reduced-motion` is implemented to be on the safe side. Currently, https://mystmd.org/guide autoplays and the fast movements are very distractive.