### PR TITLE
Add dep back for plotly builds

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -435,6 +435,7 @@
   "patchedDependencies": {
     "@remix-run/dev@1.17.1": "patches/@remix-run%2Fdev@1.17.1.patch",
     "@jupyter-widgets/controls@5.0.12": "patches/@jupyter-widgets%2Fcontrols@5.0.12.patch",
+    "jupyterlab-plotly@5.24.1": "patches/jupyterlab-plotly@5.24.1.patch",
   },
   "overrides": {
     "@types/react": "^19.2.14",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   },
   "patchedDependencies": {
     "@jupyter-widgets/controls@5.0.12": "patches/@jupyter-widgets%2Fcontrols@5.0.12.patch",
-    "@remix-run/dev@1.17.1": "patches/@remix-run%2Fdev@1.17.1.patch"
+    "@remix-run/dev@1.17.1": "patches/@remix-run%2Fdev@1.17.1.patch",
+    "jupyterlab-plotly@5.24.1": "patches/jupyterlab-plotly@5.24.1.patch"
   },
   "overrides": {
     "react": "^19.2.4",


### PR DESCRIPTION
I think this might fix the plotly issue? It seemed like this was an old dep that got lost when we moved to bun? @stefanv does this ring a bell?

this seems to [make plotly happy again](https://deploy-preview-934--myst-theme.netlify.app/reference/computation/#plotly)

<img width="1592" height="1296" alt="CleanShot 2026-07-18 at 12 18 16@2x" src="https://github.com/user-attachments/assets/4a4cd918-b03d-42c5-b0f0-0dacc4028f60" />


---

- closes #933 (maybe)