### PR TITLE
Fix TOC navigation in static build, and reduce flashing

### DIFF
--- a/.changeset/baseurl-trailing-slash.md
+++ b/.changeset/baseurl-trailing-slash.md
@@ -6,5 +6,6 @@
 ---
 
 Strip trailing slash from `BASE_URL` before use to avoid double slashes in hrefs.
-This affected the rendering of TOC and its expansion too.
+This affected the React state of TOC and its expansion.
+With no trailing slash in `BASE_URL`, have `withBaseurl` always re-insert one separating slash between `baseurl` and `url`.
 

--- a/.changeset/baseurl-trailing-slash.md
+++ b/.changeset/baseurl-trailing-slash.md
@@ -1,0 +1,10 @@
+---
+"@myst-theme/providers": patch
+"@myst-theme/site": patch
+"@myst-theme/book": patch
+"@myst-theme/article": patch
+---
+
+Strip trailing slash from `BASE_URL` before use to avoid double slashes in hrefs.
+This affected the rendering of TOC and its expansion too.
+

--- a/.changeset/baseurl-trailing-slash.md
+++ b/.changeset/baseurl-trailing-slash.md
@@ -14,3 +14,5 @@ Avoid doing a setOpen before (since animation will play once page reload finishe
 
 As an additional optimization, for now disable the TOC's open/close CSS animation entirely for static builds—we already have one flash due to the reload, so the animation feels egregious.
 
+Fix another source of flashing: the dismissible top banner determined its visible/height state (and dependents like the sidebar's position) in a `useEffect`, which runs after the browser paints. Switched to `useLayoutEffect` so that state is settled before the first paint instead of snapping into place a frame later.
+

--- a/.changeset/baseurl-trailing-slash.md
+++ b/.changeset/baseurl-trailing-slash.md
@@ -10,4 +10,7 @@ This affected the React state of TOC and its expansion.
 With no trailing slash in `BASE_URL`, have `withBaseurl` always re-insert one separating slash between `baseurl` and `url`.
 
 For static `myst build --html` exports, clicking a TOC header with a page associated does a reload.
-Avoid doing a setOpen/animation before (since animation will play once page reload finishes).
+Avoid doing a setOpen before (since animation will play once page reload finishes).
+
+As an additional optimization, for now disable the TOC's open/close CSS animation entirely for static builds—we already have one flash due to the reload, so the animation feels egregious.
+

--- a/.changeset/baseurl-trailing-slash.md
+++ b/.changeset/baseurl-trailing-slash.md
@@ -9,3 +9,5 @@ Strip trailing slash from `BASE_URL` before use to avoid double slashes in hrefs
 This affected the React state of TOC and its expansion.
 With no trailing slash in `BASE_URL`, have `withBaseurl` always re-insert one separating slash between `baseurl` and `url`.
 
+For static `myst build --html` exports, clicking a TOC header with a page associated does a reload.
+Avoid doing a setOpen/animation before (since animation will play once page reload finishes).

--- a/packages/providers/src/baseurl.spec.tsx
+++ b/packages/providers/src/baseurl.spec.tsx
@@ -1,10 +1,34 @@
 import { describe, it, expect } from 'vitest';
-import { withBaseurl, isExternalUrl } from './baseurl.js';
+import { withBaseurl, isExternalUrl, normalizeBaseurl } from './baseurl.js';
+
+describe('normalizeBaseurl', () => {
+  it('strips a trailing slash', () => {
+    expect(normalizeBaseurl('/base/')).toBe('/base');
+  });
+
+  it('strips multiple trailing slashes', () => {
+    expect(normalizeBaseurl('/base///')).toBe('/base');
+  });
+
+  it('leaves a baseurl without a trailing slash unchanged', () => {
+    expect(normalizeBaseurl('/base')).toBe('/base');
+  });
+
+  it('passes through undefined', () => {
+    expect(normalizeBaseurl(undefined)).toBe(undefined);
+  });
+});
 
 describe('withBaseurl', () => {
   it('should prepend baseurl to internal paths', () => {
     expect(withBaseurl('/about', '/base')).toBe('/base/about');
     expect(withBaseurl('/docs/page', '/base')).toBe('/base/docs/page');
+  });
+
+  it('should not produce a double slash when baseurl had a trailing slash, once normalized', () => {
+    // This is how BaseUrlProvider feeds baseurl through in practice - withBaseurl
+    // itself doesn't normalize, so a raw trailing-slash baseurl still double-slashes.
+    expect(withBaseurl('/about', normalizeBaseurl('/base/'))).toBe('/base/about');
   });
 
   it('should NOT prepend baseurl to external URLs', () => {

--- a/packages/providers/src/baseurl.spec.tsx
+++ b/packages/providers/src/baseurl.spec.tsx
@@ -25,10 +25,22 @@ describe('withBaseurl', () => {
     expect(withBaseurl('/docs/page', '/base')).toBe('/base/docs/page');
   });
 
-  it('should not produce a double slash when baseurl had a trailing slash, once normalized', () => {
-    // This is how BaseUrlProvider feeds baseurl through in practice - withBaseurl
-    // itself doesn't normalize, so a raw trailing-slash baseurl still double-slashes.
-    expect(withBaseurl('/about', normalizeBaseurl('/base/'))).toBe('/base/about');
+  it('should not produce a double slash when baseurl has a trailing slash', () => {
+    expect(withBaseurl('/about', '/base/')).toBe('/base/about');
+  });
+
+  it('should insert a separator when url has no leading slash', () => {
+    // e.g. an unresolved cross-reference falling back to a bare relative path
+    expect(withBaseurl('guides/docs', '/base')).toBe('/base/guides/docs');
+  });
+
+  it('should not double up the separator when both baseurl has a trailing slash and url lacks a leading one', () => {
+    expect(withBaseurl('guides/docs', '/base/')).toBe('/base/guides/docs');
+  });
+
+  it('should return baseurl unchanged when url is empty', () => {
+    expect(withBaseurl('', '/base')).toBe('/base');
+    expect(withBaseurl(undefined, '/base')).toBe('/base');
   });
 
   it('should NOT prepend baseurl to external URLs', () => {

--- a/packages/providers/src/baseurl.tsx
+++ b/packages/providers/src/baseurl.tsx
@@ -64,5 +64,12 @@ export function withBaseurl(url?: string, baseurl?: string) {
   if (!baseurl || isExternalUrl(url)) {
     return url as string;
   }
-  return baseurl + url;
+  if (!url) return baseurl;
+  // Ensure exactly one separating slash, regardless of whether baseurl has a
+  // trailing slash or url has a leading one - url is not always absolute (e.g.
+  // an unresolved cross-reference can fall back to a bare relative path), and
+  // naive concatenation then glues baseurl and url together with no separator.
+  const base = baseurl.replace(/\/+$/, '');
+  const path = url.startsWith('/') ? url : `/${url}`;
+  return base + path;
 }

--- a/packages/providers/src/baseurl.tsx
+++ b/packages/providers/src/baseurl.tsx
@@ -6,6 +6,13 @@ const BaseUrlContext = React.createContext<{
   baseurl?: string;
 }>({});
 
+// A trailing slash would otherwise produce double slashes wherever baseurl is
+// concatenated with a leading-slash path (see withBaseurl below), and breaks
+// matching a pathname back to its baseurl-relative path.
+export function normalizeBaseurl(baseurl?: string) {
+  return baseurl?.replace(/\/+$/, '');
+}
+
 export function BaseUrlProvider({
   baseurl,
   children,
@@ -13,7 +20,11 @@ export function BaseUrlProvider({
   baseurl?: string;
   children: React.ReactNode;
 }) {
-  return <BaseUrlContext.Provider value={{ baseurl }}>{children}</BaseUrlContext.Provider>;
+  return (
+    <BaseUrlContext.Provider value={{ baseurl: normalizeBaseurl(baseurl) }}>
+      {children}
+    </BaseUrlContext.Provider>
+  );
 }
 
 export function useBaseurl() {

--- a/packages/providers/src/theme.tsx
+++ b/packages/providers/src/theme.tsx
@@ -55,6 +55,7 @@ type ThemeContextType = {
   Link?: Link;
   NavLink?: NavLink;
   navigate?: (to: string) => void;
+  staticBuild?: boolean;
 };
 
 const ThemeContext = React.createContext<ThemeContextType | undefined>(undefined);
@@ -69,6 +70,7 @@ export function ThemeProvider({
   NavLink,
   navigate,
   top,
+  staticBuild,
 }: {
   theme: Theme | null;
   setTheme: SetThemeType;
@@ -78,12 +80,22 @@ export function ThemeProvider({
   NavLink?: NavLink;
   navigate?: (to: string) => void;
   top?: number;
+  staticBuild?: boolean;
 }) {
   const validatedRenderers = validateRenderers(renderers);
 
   return (
     <ThemeContext.Provider
-      value={{ theme, setTheme, renderers: validatedRenderers, Link, NavLink, navigate, top }}
+      value={{
+        theme,
+        setTheme,
+        renderers: validatedRenderers,
+        Link,
+        NavLink,
+        navigate,
+        top,
+        staticBuild,
+      }}
     >
       {children}
     </ThemeContext.Provider>
@@ -150,4 +162,12 @@ export function useThemeTop(): number {
   const context = React.useContext(ThemeContext);
   const { top } = context ?? {};
   return top || 0;
+}
+
+// True for `myst build --html` static exports, where Link/NavLink force a
+// hard document reload (see Document in @myst-theme/site) rather than a
+// client-side transition.
+export function useIsStaticBuild(): boolean {
+  const context = React.useContext(ThemeContext);
+  return !!context?.staticBuild;
 }

--- a/packages/site/src/components/Navigation/TableOfContentsItems.tsx
+++ b/packages/site/src/components/Navigation/TableOfContentsItems.tsx
@@ -228,7 +228,10 @@ const NestedToc = ({ heading }: { heading: NestedHeading }) => {
           </button>
         </Collapsible.Trigger>
       </div>
-      <Collapsible.Content className="pl-3 pr-[2px] collapsible-content">
+      <Collapsible.Content
+        className="pl-3 pr-[2px] collapsible-content"
+        style={isStaticBuild ? { animation: 'none' } : undefined}
+      >
         {heading.children.map((item) => (
           <NestedToc heading={item} key={item.id} />
         ))}

--- a/packages/site/src/components/Navigation/TableOfContentsItems.tsx
+++ b/packages/site/src/components/Navigation/TableOfContentsItems.tsx
@@ -166,8 +166,12 @@ const NestedToc = ({ heading }: { heading: NestedHeading }) => {
   const nav = useNavigation();
   const [open, setOpen] = React.useState(startOpen);
   useEffect(() => {
-    if (nav.state === 'idle') setOpen(startOpen);
-  }, [nav.state]);
+    // On pathname update, derive open state
+    // We don't need heading and baseurl in dependencies, since they're fixed
+    if (nav.state !== 'idle') return;
+    setOpen(childrenOpen([heading], pathname, baseurl).includes(heading.id));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nav.state, pathname]);
   const exact = pathnameMatchesHeading(pathname, heading, baseurl);
   if (!heading.children || heading.children.length === 0) {
     return (

--- a/packages/site/src/components/Navigation/TableOfContentsItems.tsx
+++ b/packages/site/src/components/Navigation/TableOfContentsItems.tsx
@@ -5,6 +5,7 @@ import type { Heading } from '@myst-theme/common';
 import {
   isExternalUrl,
   useBaseurl,
+  useIsStaticBuild,
   useLinkProvider,
   useNavLinkProvider,
   useNavOpen,
@@ -51,7 +52,7 @@ function pathnameMatchesHeading(pathname: string, heading: Heading, baseurl?: st
   // not strip the basename here).
   //
   // Also strip any trailing slash, since static builds end up with one and
-  // `heading.path` is slashless.
+  // `heading.path` needs to be without.
   let normed = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
   if (baseurl && normed.startsWith(baseurl)) normed = normed.slice(baseurl.length);
   const headingPath = heading.path;
@@ -162,6 +163,7 @@ function LinkItem({
 const NestedToc = ({ heading }: { heading: NestedHeading }) => {
   const { pathname } = useLocation();
   const baseurl = useBaseurl();
+  const isStaticBuild = useIsStaticBuild();
   const startOpen = childrenOpen([heading], pathname, baseurl).includes(heading.id);
   const nav = useNavigation();
   const [open, setOpen] = React.useState(startOpen);
@@ -202,7 +204,16 @@ const NestedToc = ({ heading }: { heading: NestedHeading }) => {
             'cursor-pointer': !heading.path,
           })}
           heading={heading}
-          onClick={() => setOpen(heading.path ? true : !open)}
+          onClick={() => {
+            if (heading.path) {
+              // Clicking a header with its own page navigates away.
+              // We don't want to animate before doing so, since after the reload there will be an animation anyway.
+              // So, only perform the open for non-static build.
+              if (!isStaticBuild) setOpen(true);
+              return;
+            }
+            setOpen(!open);
+          }}
         />
         <Collapsible.Trigger asChild>
           <button

--- a/packages/site/src/pages/Root.tsx
+++ b/packages/site/src/pages/Root.tsx
@@ -80,7 +80,14 @@ export function Document({
   );
 
   return (
-    <ThemeProvider theme={theme} setTheme={setTheme} renderers={renderers} {...links} top={top}>
+    <ThemeProvider
+      theme={theme}
+      setTheme={setTheme}
+      renderers={renderers}
+      {...links}
+      top={top}
+      staticBuild={staticBuild}
+    >
       <DocumentWithoutProviders
         children={children}
         scripts={scripts}

--- a/themes/article/app/root.tsx
+++ b/themes/article/app/root.tsx
@@ -15,7 +15,7 @@ import {
 export { AppErrorBoundary as ErrorBoundary } from '@myst-theme/site';
 import { Outlet, useLoaderData } from '@remix-run/react';
 import type { NodeRenderers } from '@myst-theme/providers';
-import { mergeRenderers } from '@myst-theme/providers';
+import { mergeRenderers, normalizeBaseurl } from '@myst-theme/providers';
 import { JUPYTER_RENDERERS } from '@myst-theme/jupyter';
 import { ANY_RENDERERS } from '@myst-theme/anywidget';
 
@@ -59,7 +59,7 @@ export const loader: LoaderFunction = async ({ request }): Promise<SiteLoader> =
     config,
     CONTENT_CDN_PORT: process.env.CONTENT_CDN_PORT ?? 3100,
     MODE: (process.env.MODE ?? 'app') as 'app' | 'static',
-    BASE_URL: process.env.BASE_URL || undefined,
+    BASE_URL: normalizeBaseurl(process.env.BASE_URL) || undefined,
   };
   return data;
 };

--- a/themes/book/app/components/Banner.tsx
+++ b/themes/book/app/components/Banner.tsx
@@ -1,10 +1,15 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import { MyST } from 'myst-to-react';
 import classNames from 'classnames';
 import type { GenericParent } from 'myst-common';
 import { hashString } from '~/utils/hash';
 import { XMarkIcon } from '@heroicons/react/24/solid';
 import { useBannerState } from '@myst-theme/providers';
+
+// useLayoutEffect on the client so bannerState.visible/height (and anything
+// that positions off them, e.g. the sidebar) are determined before first paint.
+// `useLayoutEffect` would warn in SSR, so there use `useEffect` instead.
+const useIsomorphicLayoutEffect = typeof document !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
  * A dismissible banner component at the top that shows content passed as a MyST AST.
@@ -22,7 +27,7 @@ export function Banner({ content, className }: { content: GenericParent; classNa
 
   // Check dismissal state on client side
   // If the banner content changes, the ID will be different and it'll show again
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const el = ref.current;
 
     const dismissed = localStorage.getItem(`myst-dismissed-banner-${bannerId}`) === 'true';

--- a/themes/book/app/root.tsx
+++ b/themes/book/app/root.tsx
@@ -15,7 +15,7 @@ import {
 export { AppErrorBoundary as ErrorBoundary } from '@myst-theme/site';
 import { createSearch as createMiniSearch } from '@myst-theme/search-minisearch';
 import { Outlet, useLoaderData } from '@remix-run/react';
-import { SearchFactoryProvider, mergeRenderers } from '@myst-theme/providers';
+import { SearchFactoryProvider, mergeRenderers, normalizeBaseurl } from '@myst-theme/providers';
 import type { NodeRenderers } from '@myst-theme/providers';
 import type { ISearch, MystSearchIndex } from '@myst-theme/search';
 import { SEARCH_ATTRIBUTES_ORDERED } from '@myst-theme/search';
@@ -56,7 +56,7 @@ export const links: LinksFunction = () => {
 };
 
 export const loader: LoaderFunction = async ({ request }): Promise<SiteLoader> => {
-  const baseURL = process.env.BASE_URL || undefined;
+  const baseURL = normalizeBaseurl(process.env.BASE_URL) || undefined;
   const [config, themeSession] = await Promise.all([
     getConfig().catch(() => null),
     getThemeSession(request),


### PR DESCRIPTION
A trailing-slash BASE_URL (e.g. /development/) broke
withBaseurl (double slashes in generated hrefs/favicon/stylesheet
links), and TOC sections never auto-expanded.

Normalize once in BaseUrlProvider and whenever each theme accesses the
environement variable.

Also fix NestedToc's sync effect to compute the open state from
pathname, instead of using the startOpen value.

Closes #910