### PR TITLE
Fix top-nav dropdown children ignoring `internal_domains`

### DIFF
--- a/.changeset/nav-dropdown-internal-domains.md
+++ b/.changeset/nav-dropdown-internal-domains.md
@@ -1,0 +1,5 @@
+---
+"@myst-theme/site": patch
+---
+
+Fix top-nav dropdown children ignoring `internal_domains`, so fully-qualified internal URLs open in the same tab instead of always opening in a new tab

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -8,6 +8,7 @@ import { MyST } from 'myst-to-react';
 import { ThemeButton } from './ThemeButton.js';
 import { Search } from './Search.js';
 import {
+  isExternalUrl,
   useBaseurl,
   useNavLinkProvider,
   useNavOpen,
@@ -24,6 +25,7 @@ export const DEFAULT_NAV_HEIGHT = 60;
 export function NavItem({ item }: { item: SiteNavItem }) {
   const NavLink = useNavLinkProvider();
   const baseurl = useBaseurl();
+  const config = useSiteManifest();
   if (!('children' in item)) {
     return (
       <div className="myst-top-nav-item relative inline-block mx-2 grow-0">
@@ -67,7 +69,7 @@ export function NavItem({ item }: { item: SiteNavItem }) {
             return (
               <Menu.Item key={action.url}>
                 {/* This is really ugly, BUT, the action needs to be defined HERE or the click away doesn't work for some reason */}
-                {action.url?.startsWith('http') ? (
+                {isExternalUrl(action.url, config?.options?.internal_domains) ? (
                   <a
                     href={url}
                     className="myst-top-nav-dropdown-item block px-4 py-2 text-sm text-myst-text hover:bg-myst-surface"


### PR DESCRIPTION
Fix top-nav dropdown children ignoring `internal_domains`, so fully-qualified internal URLs open in the same tab instead of always opening in a new tab.

When [combining multiple repos using the BASE_URL](https://jupyterbook.org/blog/posts/2026/multi-repo) and sharing a top nav, links need to use fully specified URLs or the subsites will add BASE_URL to relative URLs.  At the same time the current code does not perform an internal-domain check for children in the top nav menu items so these always open a new tab (`target="_blank"`).  So a catch-22 when trying to use children in the shared top nav.