### PR TITLE
Make sidebar overlay show even without toc

### DIFF
--- a/docs/reference/hide-toc.md
+++ b/docs/reference/hide-toc.md
@@ -1,0 +1,17 @@
+---
+title: Hidden table of contents
+site:
+  hide_toc: true
+---
+
+This page sets `site.hide_toc: true` in its frontmatter, like a landing page.
+It demonstrates the sidebar behavior when there is no table of contents:
+
+- Below the `lg` breakpoint (1024px), the top-bar nav links collapse into a hamburger menu.
+  Opening it shows the sidebar with the nav links, behind a darkened overlay.
+  Clicking the overlay closes the sidebar.
+- At `lg` and above, the nav links are in the top bar, so the sidebar, hamburger, and overlay are all hidden.
+  If you open the menu on a narrow window and then widen it past 1024px, the overlay must disappear with the sidebar.
+
+Compare with any other page in these docs, which has a table of contents:
+there the sidebar (and its overlay when open) persists up to the `xl` breakpoint (1280px), where the TOC moves into its own column.

--- a/docs/reference/hide-toc.md
+++ b/docs/reference/hide-toc.md
@@ -1,11 +1,14 @@
 ---
-title: Hidden table of contents
+title: Hidden sidebars
 site:
   hide_toc: true
 ---
 
 This page sets `site.hide_toc: true` in its frontmatter, like a landing page.
-It demonstrates the sidebar behavior when there is no table of contents:
+It demonstrates the behavior when there is no table of contents.
+Right now this is mostly to demo sidebar behavior.
+
+## Hidden table of contents
 
 - Below the `lg` breakpoint (1024px), the top-bar nav links collapse into a hamburger menu.
   Opening it shows the sidebar with the nav links, behind a darkened overlay.

--- a/packages/site/src/components/Navigation/Navigation.tsx
+++ b/packages/site/src/components/Navigation/Navigation.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { useNavOpen, useSiteManifest, useThemeTop } from '@myst-theme/providers';
 import { PrimarySidebar } from './PrimarySidebar.js';
 import type { Heading } from '@myst-theme/common';
@@ -96,12 +97,17 @@ export const ConfigurablePrimaryNavigation = ({
 
   return (
     <>
-      {open && !mobileOnly && headings && (
+      {open && !mobileOnly && (
         // Darkened backdrop behind the open sidebar on mobile.
         <div
           // It follows the same top-offset rules as the sidebar: header offset on desktop,
           // full-screen from top on mobile.
-          className="myst-navigation-overlay fixed inset-0 max-xl:z-40 xl:z-30 bg-black opacity-50 max-xl:!mt-0"
+          className={classNames(
+            'myst-navigation-overlay fixed inset-0 max-xl:z-40 xl:z-30 bg-black opacity-50 max-xl:!mt-0',
+            // If there is no TOC then the overlay should hide at lg
+            // If there *is* a TOC then the overlay hides at xl
+            { 'lg:hidden': nav && hide_toc },
+          )}
           style={{ marginTop: top }}
           // Clicking the backdrop is the primary escape path for closing the sidebar.
           onClick={() => setOpen(false)}


### PR DESCRIPTION
I think this fixes the bug where the sidebar "click to hide" overlay doesn't show up on mobile for pages that use `hide_toc`.

This new demo page shows the working sidebar overlay now https://deploy-preview-946--myst-theme.netlify.app/reference/hide-toc/

- closes #945 