### PR TITLE
Render breadcrumbs in the book theme

### DIFF
--- a/.changeset/book-breadcrumbs.md
+++ b/.changeset/book-breadcrumbs.md
@@ -6,3 +6,4 @@
 ---
 
 Add a breadcrumb trail above the page title in the book theme, showing the page's ancestors from the table of contents.
+The top nav now renders at the 60px height that `DEFAULT_NAV_HEIGHT` uses, so the sidebar / outline / heading scroll line up.

--- a/.changeset/book-breadcrumbs.md
+++ b/.changeset/book-breadcrumbs.md
@@ -1,0 +1,8 @@
+---
+"@myst-theme/common": minor
+"@myst-theme/frontmatter": minor
+"@myst-theme/site": minor
+"@myst-theme/book": minor
+---
+
+Add a breadcrumb trail above the page title in the book theme, showing the page's ancestors from the table of contents.

--- a/docs/reference/title-block.md
+++ b/docs/reference/title-block.md
@@ -1,0 +1,13 @@
+---
+title: Title block with a subject and a long title that needs a short title
+short_title: Title block
+subject: Reference
+subtitle: A page that exists to show off the header row above the title
+---
+
+# Title block
+
+This page sets `subject`, `subtitle`, and `short_title` in its frontmatter.
+
+- The `subject` appears in the header row, next to the breadcrumbs.
+- The breadcrumbs and the sidebar use `short_title`, while the page content uses the full `title`.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -55,10 +55,15 @@ site:
 
 The book theme shows a breadcrumb trail above the page title, for example `🏠 › Reference › Admonitions`.
 The trail follows the nesting of your table of contents in `myst.yml`, using each page's `short_title` when set.
-Sections that have a title but no page of their own appear as plain text.
-The article theme does not show breadcrumbs.
 
 Turn breadcrumbs off with [`hide_breadcrumbs`](#hide-breadcrumbs).
+
+A few notes:
+
+- Sections that have a title but no page of their own appear as plain text.
+- If you're using numbered sections, they will *not* show up in the breadcrumbs.
+- If you set a `subject:` for the page, it'll show up to the right of the breadcrumbs.
+- The article theme does not show breadcrumbs.
 
 ## Banner
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -50,6 +50,16 @@ site:
           url: /reference
 ```
 
+(breadcrumbs)=
+## Breadcrumbs
+
+The book theme shows a breadcrumb trail above the page title, for example `🏠 › Reference › Admonitions`.
+The trail follows the nesting of your table of contents in `myst.yml`, using each page's `short_title` when set.
+Sections that have a title but no page of their own appear as plain text.
+The article theme does not show breadcrumbs.
+
+Turn breadcrumbs off with [`hide_breadcrumbs`](#hide-breadcrumbs).
+
 ## Banner
 
 Display an announcement bar at the top of your site.
@@ -173,6 +183,16 @@ Hide the right sidebar document outline.
 site:
   options:
     hide_outline: true
+```
+
+### Hide Breadcrumbs
+
+Hide the [breadcrumb trail](#breadcrumbs) shown above the page title.
+
+```yaml
+site:
+  options:
+    hide_breadcrumbs: true
 ```
 
 ### Hide Title Block

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -49,6 +49,11 @@ export type FooterLinks = {
   };
 };
 
+export type BreadcrumbItem = {
+  title: string;
+  path?: string;
+};
+
 export type PageFrontmatterWithDownloads = Omit<
   PageFrontmatter,
   'parts' | 'downloads' | 'exports'
@@ -89,5 +94,6 @@ export type CommonTemplateOptions = {
   hide_footer_links?: boolean;
   hide_toc?: boolean;
   hide_outline?: boolean;
+  hide_breadcrumbs?: boolean;
   outline_maxdepth?: number;
 };

--- a/packages/common/src/utils.spec.ts
+++ b/packages/common/src/utils.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { isFlatSite, parsePathname } from './utils.js';
+import { isFlatSite, parsePathname, getBreadcrumbs } from './utils.js';
+import type { SiteManifest } from 'myst-config';
 
 describe('utils', () => {
   test('isFlatSite true', () => {
@@ -39,5 +40,64 @@ describe('parsePathname', () => {
     expect(parsePathname('/community/')).toEqual(['community']);
     expect(parsePathname('/community')).toEqual(['community']);
     expect(parsePathname('/project/page/')).toEqual(['project', 'page']);
+  });
+});
+
+function makeConfig(pages: Record<string, unknown>[]): SiteManifest {
+  return {
+    myst: 'v1',
+    projects: [{ slug: undefined, index: 'index', title: 'Test Project', pages }],
+  } as unknown as SiteManifest;
+}
+
+describe('getBreadcrumbs', () => {
+  const config = makeConfig([
+    { slug: 'guide', title: 'Guide', level: 1 },
+    { slug: 'reference.index', title: 'Reference', short_title: 'Ref', level: 1 },
+    { slug: 'reference.blocks', title: 'Blocks', level: 2 },
+    { slug: 'reference.breadcrumbs.index', title: 'Breadcrumbs', level: 2 },
+    { slug: 'reference.breadcrumbs.child', title: 'Child Page', level: 3 },
+  ]);
+
+  test('returns empty for index page, undefined slug, unknown slug', () => {
+    expect(getBreadcrumbs(config, undefined, 'index')).toEqual([]);
+    expect(getBreadcrumbs(config, undefined, undefined)).toEqual([]);
+    expect(getBreadcrumbs(config, undefined, 'nonexistent')).toEqual([]);
+  });
+
+  test('level-1 page', () => {
+    expect(getBreadcrumbs(config, undefined, 'guide')).toEqual([
+      { title: 'Test Project', path: '/' },
+      { title: 'Guide' },
+    ]);
+  });
+
+  test('level-3 page, preferring short_title', () => {
+    expect(getBreadcrumbs(config, undefined, 'reference.breadcrumbs.child')).toEqual([
+      { title: 'Test Project', path: '/' },
+      { title: 'Ref', path: '/reference' },
+      { title: 'Breadcrumbs', path: '/reference/breadcrumbs' },
+      { title: 'Child Page' },
+    ]);
+  });
+
+  test('nested page with no level-1 ancestor goes straight to the root', () => {
+    const noParent = makeConfig([{ slug: 'solo', title: 'Solo', level: 2 }]);
+    expect(getBreadcrumbs(noParent, undefined, 'solo')).toEqual([
+      { title: 'Test Project', path: '/' },
+      { title: 'Solo' },
+    ]);
+  });
+
+  test('slug-less "Part" heading is an unlinked crumb', () => {
+    const withPart = makeConfig([
+      { title: 'Part 1', level: 1 },
+      { slug: 'part1.chapter2', title: 'Chapter 2', level: 2 },
+    ]);
+    expect(getBreadcrumbs(withPart, undefined, 'part1.chapter2')).toEqual([
+      { title: 'Test Project', path: '/' },
+      { title: 'Part 1' },
+      { title: 'Chapter 2' },
+    ]);
   });
 });

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -3,7 +3,7 @@ import { walkOutputs } from 'nbtx';
 import type { SiteManifest } from 'myst-config';
 import { selectAll } from 'unist-util-select';
 import type { Image as ImageSpec, Link as LinkSpec } from 'myst-spec';
-import type { FooterLinks, Heading, NavigationLink, PageLoader } from './types.js';
+import type { BreadcrumbItem, FooterLinks, Heading, NavigationLink, PageLoader } from './types.js';
 import type { GenericParent } from 'myst-common';
 import { slugToUrl } from 'myst-common';
 
@@ -92,6 +92,41 @@ export function getFooterLinks(
     navigation: { prev, next },
   };
   return footer;
+}
+
+/**
+ * Build a breadcrumb trail for a given page using the site manifest + page slug.
+ * Ancestors without a slug, e.g. a "Part" heading, are included without a path.
+ */
+export function getBreadcrumbs(
+  config?: SiteManifest,
+  projectSlug?: string,
+  slug?: string,
+): BreadcrumbItem[] {
+  if (!slug || !config) return [];
+  const headings = getProjectHeadings(config, projectSlug) ?? [];
+  const found = headings.findIndex((h) => h.slug === slug);
+  if (found <= 0) return []; // unknown slug, or the project index itself
+  // These functions pull our metadata for each breadcrumb item
+  const titleOf = (h: Heading) => h.short_title || h.title;
+  const asItem = (h: Heading): BreadcrumbItem => ({ title: titleOf(h), path: h.path });
+  // Now build up the breadcrumb items by walking the ancestors of the page
+  const trail: BreadcrumbItem[] = [];
+  let level = headings[found].level as number;
+  for (let i = found - 1; i >= 0; i--) {
+    const h = headings[i];
+    // If we're at the top, it's time to stop!
+    if (h.level === 'index') {
+      trail.unshift(asItem(h));
+      break;
+    }
+    if (h.level < level) {
+      level = h.level;
+      trail.unshift(asItem(h));
+    }
+  }
+  trail.push({ title: titleOf(headings[found]) });
+  return trail;
 }
 
 type UpdateUrl = (url: string) => string;

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -263,7 +263,8 @@ export function FrontmatterBlock({
   const hasBadges = !!open_access || !!license || !!hasExports || !!isJupyter || !!github;
   const hasHeaders = !!subject || !!venue || !!volume || !!issue;
   const hasDateOrDoi = !!doi || !!date;
-  const showHeaderBlock = !!breadcrumbs || hasHeaders || (hasBadges && !hideBadges) || (hasExports && !hideExports);
+  const showHeaderBlock =
+    !!breadcrumbs || hasHeaders || (hasBadges && !hideBadges) || (hasExports && !hideExports);
   const hideLaunch: boolean = false;
 
   if (!title && !subtitle && !showHeaderBlock && !hasAuthors && !hasDateOrDoi) {

--- a/packages/frontmatter/src/FrontmatterBlock.tsx
+++ b/packages/frontmatter/src/FrontmatterBlock.tsx
@@ -225,6 +225,7 @@ export function FrontmatterBlock({
   className,
   thebe,
   location,
+  breadcrumbs,
 }: {
   frontmatter: Omit<PageFrontmatter, 'parts'>;
   kind?: SourceFileKind;
@@ -235,6 +236,7 @@ export function FrontmatterBlock({
   className?: string;
   thebe?: ExpandedThebeFrontmatter;
   location?: string;
+  breadcrumbs?: React.ReactNode;
 }) {
   if (!frontmatter) return null;
   const {
@@ -261,7 +263,7 @@ export function FrontmatterBlock({
   const hasBadges = !!open_access || !!license || !!hasExports || !!isJupyter || !!github;
   const hasHeaders = !!subject || !!venue || !!volume || !!issue;
   const hasDateOrDoi = !!doi || !!date;
-  const showHeaderBlock = hasHeaders || (hasBadges && !hideBadges) || (hasExports && !hideExports);
+  const showHeaderBlock = !!breadcrumbs || hasHeaders || (hasBadges && !hideBadges) || (hasExports && !hideExports);
   const hideLaunch: boolean = false;
 
   if (!title && !subtitle && !showHeaderBlock && !hasAuthors && !hasDateOrDoi) {
@@ -275,10 +277,12 @@ export function FrontmatterBlock({
       className={classNames('myst-fm-block', className)}
     >
       {showHeaderBlock && (
-        <div className="myst-fm-block-header flex items-center mb-5 h-6 text-sm font-light">
+        <div className="myst-fm-block-header flex items-center mb-5 min-h-[1.5rem] text-sm font-light">
+          {breadcrumbs}
           {subject && (
             <div
               className={classNames('myst-fm-block-subject flex-none pr-2 smallcaps', {
+                'pl-2 border-l': breadcrumbs, // if we have breadcrumbs, add a left border
                 'mr-2 border-r': venue,
               })}
             >

--- a/packages/site/src/components/Navigation/Breadcrumbs.tsx
+++ b/packages/site/src/components/Navigation/Breadcrumbs.tsx
@@ -8,7 +8,7 @@ export function Breadcrumbs({ items }: { items: BreadcrumbItem[] }) {
   const baseurl = useBaseurl();
   const Link = useLinkProvider();
   return (
-    <nav aria-label="Breadcrumb" className="myst-breadcrumbs min-w-0 mr-2">
+    <nav aria-label="Breadcrumb" className="myst-breadcrumbs not-prose min-w-0 mr-2">
       <ol className="flex flex-wrap items-center gap-1 pl-0 my-0 list-none text-myst-text-secondary">
         {items.map((item, index) => {
           const isFirst = index === 0;

--- a/packages/site/src/components/Navigation/Breadcrumbs.tsx
+++ b/packages/site/src/components/Navigation/Breadcrumbs.tsx
@@ -1,0 +1,51 @@
+import classNames from 'classnames';
+import type { BreadcrumbItem } from '@myst-theme/common';
+import { useBaseurl, useLinkProvider, withBaseurl } from '@myst-theme/providers';
+import { ChevronRightIcon, HomeIcon } from '@heroicons/react/24/solid';
+
+/** Render a breadcrumb trail. `items` comes from `getBreadcrumbs()` */
+export function Breadcrumbs({ items }: { items: BreadcrumbItem[] }) {
+  const baseurl = useBaseurl();
+  const Link = useLinkProvider();
+  return (
+    <nav aria-label="Breadcrumb" className="myst-breadcrumbs min-w-0 mr-2">
+      <ol className="flex flex-wrap items-center gap-1 pl-0 my-0 list-none text-myst-text-secondary">
+        {items.map((item, index) => {
+          const isFirst = index === 0;
+          const isLast = index === items.length - 1;
+          const label = isFirst ? (
+            <>
+              <HomeIcon className="w-4 h-4" />
+              <span className="sr-only">{item.title}</span>
+            </>
+          ) : (
+            <span className="truncate max-w-[12rem]">{item.title}</span>
+          );
+          return (
+            <li key={index} className="flex items-center gap-1">
+              {!isFirst && (
+                <ChevronRightIcon aria-hidden className="flex-none w-3 h-3 opacity-60" />
+              )}
+              {item.path && !isLast ? (
+                <Link
+                  prefetch="intent"
+                  to={withBaseurl(item.path, baseurl)}
+                  className="myst-breadcrumbs-link flex items-center gap-1 no-underline text-inherit hover:text-myst-active"
+                >
+                  {label}
+                </Link>
+              ) : (
+                <span
+                  aria-current={isLast ? 'page' : undefined}
+                  className={classNames('flex items-center', { 'text-myst-text': isLast })}
+                >
+                  {label}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -131,7 +131,7 @@ export function TopNav({
   //   cause a mismatch if the navbar grows. Here we set it to `min-h` to let
   //   it grow, but we'll need to revisit downstream height consumers eventually.
   return (
-    <div className="myst-top-nav myst-bg-translucent backdrop-blur shadow dark:shadow-2xl p-3 md:px-8 sticky w-full top-0 z-30 min-h-[60px]">
+    <div className="myst-top-nav myst-bg-translucent backdrop-blur shadow dark:shadow-2xl px-3 py-2.5 md:px-8 sticky w-full top-0 z-30 min-h-[60px]">
       <nav className="myst-top-nav-bar flex items-center justify-between flex-nowrap max-w-[1440px] mx-auto">
         <div className="flex flex-row xl:min-w-[19.5rem] mr-2 sm:mr-7 justify-start items-center shrink-0">
           {

--- a/packages/site/src/components/Navigation/index.tsx
+++ b/packages/site/src/components/Navigation/index.tsx
@@ -6,3 +6,4 @@ export { InlineTableOfContents } from './InlineTableOfContents.js';
 export { LoadingBar } from './Loading.js';
 export { ActionMenu } from './ActionMenu.js';
 export { HomeLink } from './HomeLink.js';
+export { Breadcrumbs } from './Breadcrumbs.js';

--- a/themes/book/app/components/ArticlePage.tsx
+++ b/themes/book/app/components/ArticlePage.tsx
@@ -8,6 +8,7 @@ import {
 } from '@myst-theme/providers';
 import {
   Bibliography,
+  Breadcrumbs,
   FooterLinksBlock,
   FrontmatterParts,
   BackmatterParts,
@@ -16,7 +17,7 @@ import {
   Footnotes,
 } from '@myst-theme/site';
 import type { SiteManifest } from 'myst-config';
-import type { PageLoader } from '@myst-theme/common';
+import { getBreadcrumbs, type PageLoader } from '@myst-theme/common';
 import { copyNode, type GenericParent } from 'myst-common';
 import { SourceFileKind } from 'myst-spec-ext';
 import {
@@ -65,13 +66,21 @@ export const ArticlePage = React.memo(function ({
   const top = useThemeTop();
 
   const pageDesign: TemplateOptions = (article.frontmatter as any)?.site ?? {};
+  const siteManifest = useSiteManifest();
   const siteDesign: TemplateOptions =
-    (useSiteManifest() as SiteManifest & TemplateOptions)?.options ?? {};
-  const { hide_title_block, hide_footer_links, hide_outline, outline_maxdepth, hide_authors } = {
-    ...siteDesign,
-    ...pageDesign,
-  };
+    (siteManifest as SiteManifest & TemplateOptions)?.options ?? {};
+  const {
+    hide_title_block,
+    hide_footer_links,
+    hide_outline,
+    hide_breadcrumbs,
+    outline_maxdepth,
+    hide_authors,
+  } = { ...siteDesign, ...pageDesign };
   const downloads = combineDownloads(manifest?.downloads, article.frontmatter);
+  const breadcrumbs = hide_breadcrumbs
+    ? []
+    : getBreadcrumbs(siteManifest, article.project, article.slug);
   const tree = copyNode(article.mdast);
   const keywords = article.frontmatter?.keywords ?? [];
   const parts = extractKnownParts(tree, article.frontmatter?.parts);
@@ -95,6 +104,7 @@ export const ArticlePage = React.memo(function ({
               thebe={thebe}
               location={location}
               hideAuthors={hide_authors}
+              breadcrumbs={breadcrumbs.length > 0 && <Breadcrumbs items={breadcrumbs} />}
             />
           )}
           {!hide_outline && (

--- a/themes/book/app/components/ArticlePage.tsx
+++ b/themes/book/app/components/ArticlePage.tsx
@@ -113,7 +113,7 @@ export const ArticlePage = React.memo(function ({
               style={{ top }}
             >
               <DocumentOutline
-                className="relative mt-9"
+                className="relative mt-7"
                 maxdepth={outline_maxdepth}
                 isMargin={isOutlineMargin}
               />

--- a/themes/book/template.yml
+++ b/themes/book/template.yml
@@ -23,6 +23,9 @@ options:
     id: hide_outline
     description: Hide the document outline on all pages
   - type: boolean
+    id: hide_breadcrumbs
+    description: Hide the breadcrumb trail above the page title
+  - type: boolean
     id: hide_title_block
     description: Hide the document title on all pages
   - type: boolean


### PR DESCRIPTION
This adds parent breadcrumbs to pages in the book theme. It doesn't touch the article theme!

<img width="800" height="216" alt="CleanShot 2026-09-04 at 15 41 53" src="https://github.com/user-attachments/assets/bf8893d8-3df6-497d-8da7-1347125b0629" />

### Decisions I made

- It lives just to the left of the "github for the page" buttons - that is usually whitespace and felt like the natural place to put this.
- It uses the site manifest to figure out who the parents are etc, so the URLs come from the myst build and we don't have to worry about `folders` changing behavior
- The "home" link is shown on every page other than the landing page - I figure for the landing page, you often want a different UI setup
- If the TOC has a title but no URL/file attached to it, it'll show up as an unlinked word but will still be in the breadcrumbs!
- If `subject` is also defined on a page it adds a little `|` and puts the subject to the right of the breadcrumbs, instead of clobbering it. It felt like this was a bit less-disruptive.
- That line can now grow to take up multiple lines for narrow screens or really long breadcrumb trails
- If short-title is defined, it uses that
- If it's a really long title, it'll get truncated with a `...`
- Vertically aligned the two sidebars and the meta / breadcrumbs area with light whitespace adjustments

### Concerns

- I feel like there's a lot of "UI" taking up the vertical space in general. I'd be a fan of shrinking down some of the padding so that the page title is a bit higher up, but that felt out of scope for this.

### Examples

<details>
<summary>Wide</summary>

<img width="2986" height="812" alt="CleanShot 2026-09-03 at 16 18 42@2x" src="https://github.com/user-attachments/assets/e149b9a6-3aed-4339-afb1-480c169c92ef" />


</details>

<details>
<summary>Mobile</summary>

<img width="578" height="812" alt="CleanShot 2026-09-03 at 16 14 07@2x" src="https://github.com/user-attachments/assets/2c995602-8f08-462c-9152-c357fe361582" />

</details>

_Used Claude Fable to help with the implementation, along with the [`/grill-me` skill](https://www.aihero.dev/skills-grill-me) to do a bunch of design question exploration before getting to implementation, and in a few rounds of subsequent iteration on the end outcome. Then I went through and added comments and cleaned up the code here and there so it made more sense to me...I should really write this up in a blog post or something so that I don't have to write it every time 😅_

---

- closes #817 